### PR TITLE
Update travis script to support testing_codelab

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -21,7 +21,12 @@ declare -a PROJECT_PATHS=($(find . -not -path './flutter/*' -not -path './Plugin
 
 for PROJECT in "${PROJECT_PATHS[@]}"; do
   echo "== TESTING $PROJECT"
-  $FLUTTER create --no-overwrite "$PROJECT"
+  
+  # Do not recreate project for testing_codelab.
+  if ! [[ "$PROJECT" == *"testing_codelab"* ]]; then
+    $FLUTTER create --no-overwrite "$PROJECT"
+  fi
+  
   (
     cd "$PROJECT";
     set -x;


### PR DESCRIPTION
Updated the Travis script to stop recreating project for `testing_codelab`.

@domesticmouse if you think there's a better way to do this, feel free to suggest changes.