### PR TITLE
Update obsolete button references in website/examples/codelabs

### DIFF
--- a/firebase-get-to-know-flutter/step_02/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_02/lib/src/authentication.dart
@@ -303,8 +303,7 @@ class _RegisterFormState extends State<RegisterForm> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      FlatButton(
-                        highlightColor: Colors.deepPurple,
+                      TextButton(
                         onPressed: widget.cancel,
                         child: Text('CANCEL'),
                       ),

--- a/firebase-get-to-know-flutter/step_02/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_02/lib/src/widgets.dart
@@ -55,7 +55,8 @@ class StyledButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => OutlinedButton(
-        style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.deepPurple)),
+        style: OutlinedButton.styleFrom(
+            side: BorderSide(color: Colors.deepPurple)),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_02/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_02/lib/src/widgets.dart
@@ -54,8 +54,8 @@ class StyledButton extends StatelessWidget {
   final void Function() onPressed;
 
   @override
-  Widget build(BuildContext context) => OutlineButton(
-        borderSide: BorderSide(color: Colors.deepPurple),
+  Widget build(BuildContext context) => OutlinedButton(
+        style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.deepPurple)),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_04/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_04/lib/src/authentication.dart
@@ -303,8 +303,7 @@ class _RegisterFormState extends State<RegisterForm> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      FlatButton(
-                        highlightColor: Colors.deepPurple,
+                      TextButton(
                         onPressed: widget.cancel,
                         child: Text('CANCEL'),
                       ),

--- a/firebase-get-to-know-flutter/step_04/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_04/lib/src/widgets.dart
@@ -54,8 +54,10 @@ class StyledButton extends StatelessWidget {
   final void Function() onPressed;
 
   @override
-  Widget build(BuildContext context) => OutlineButton(
-        borderSide: BorderSide(color: Colors.deepPurple),
+  Widget build(BuildContext context) => OutlinedButton(
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(color: Colors.deepPurple),
+        ),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_05/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_05/lib/src/authentication.dart
@@ -303,8 +303,7 @@ class _RegisterFormState extends State<RegisterForm> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      FlatButton(
-                        highlightColor: Colors.deepPurple,
+                      TextButton(
                         onPressed: widget.cancel,
                         child: Text('CANCEL'),
                       ),

--- a/firebase-get-to-know-flutter/step_05/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_05/lib/src/widgets.dart
@@ -55,7 +55,8 @@ class StyledButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => OutlinedButton(
-        style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.deepPurple)),
+        style: OutlinedButton.styleFrom(
+            side: BorderSide(color: Colors.deepPurple)),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_05/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_05/lib/src/widgets.dart
@@ -54,8 +54,8 @@ class StyledButton extends StatelessWidget {
   final void Function() onPressed;
 
   @override
-  Widget build(BuildContext context) => OutlineButton(
-        borderSide: BorderSide(color: Colors.deepPurple),
+  Widget build(BuildContext context) => OutlinedButton(
+        style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.deepPurple)),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_06/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_06/lib/src/authentication.dart
@@ -303,8 +303,7 @@ class _RegisterFormState extends State<RegisterForm> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      FlatButton(
-                        highlightColor: Colors.deepPurple,
+                      TextButton(
                         onPressed: widget.cancel,
                         child: Text('CANCEL'),
                       ),

--- a/firebase-get-to-know-flutter/step_06/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_06/lib/src/widgets.dart
@@ -55,7 +55,8 @@ class StyledButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => OutlinedButton(
-        style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.deepPurple)),
+        style: OutlinedButton.styleFrom(
+            side: BorderSide(color: Colors.deepPurple)),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_06/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_06/lib/src/widgets.dart
@@ -54,8 +54,8 @@ class StyledButton extends StatelessWidget {
   final void Function() onPressed;
 
   @override
-  Widget build(BuildContext context) => OutlineButton(
-        borderSide: BorderSide(color: Colors.deepPurple),
+  Widget build(BuildContext context) => OutlinedButton(
+        style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.deepPurple)),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_07/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_07/lib/src/authentication.dart
@@ -303,8 +303,7 @@ class _RegisterFormState extends State<RegisterForm> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      FlatButton(
-                        highlightColor: Colors.deepPurple,
+                      TextButton(
                         onPressed: widget.cancel,
                         child: Text('CANCEL'),
                       ),

--- a/firebase-get-to-know-flutter/step_07/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_07/lib/src/widgets.dart
@@ -54,8 +54,10 @@ class StyledButton extends StatelessWidget {
   final void Function() onPressed;
 
   @override
-  Widget build(BuildContext context) => OutlineButton(
-        borderSide: BorderSide(color: Colors.deepPurple),
+  Widget build(BuildContext context) => OutlinedButton(
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(color: Colors.deepPurple),
+        ),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_09/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_09/lib/main.dart
@@ -24,9 +24,6 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: 'Firebase Meetup',
       theme: ThemeData(
-        buttonTheme: Theme.of(context).buttonTheme.copyWith(
-              highlightColor: Colors.deepPurple,
-            ),
         primarySwatch: Colors.deepPurple,
         textTheme: GoogleFonts.robotoTextTheme(
           Theme.of(context).textTheme,
@@ -357,16 +354,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),
@@ -378,16 +372,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),

--- a/firebase-get-to-know-flutter/step_09/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_09/lib/src/authentication.dart
@@ -303,8 +303,7 @@ class _RegisterFormState extends State<RegisterForm> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      FlatButton(
-                        highlightColor: Colors.deepPurple,
+                      TextButton(
                         onPressed: widget.cancel,
                         child: Text('CANCEL'),
                       ),

--- a/firebase-get-to-know-flutter/step_09/lib/src/widgets.dart
+++ b/firebase-get-to-know-flutter/step_09/lib/src/widgets.dart
@@ -54,8 +54,10 @@ class StyledButton extends StatelessWidget {
   final void Function() onPressed;
 
   @override
-  Widget build(BuildContext context) => OutlineButton(
-        borderSide: BorderSide(color: Colors.deepPurple),
+  Widget build(BuildContext context) => OutlinedButton(
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(color: Colors.deepPurple),
+        ),
         onPressed: onPressed,
         child: child,
       );

--- a/firebase-get-to-know-flutter/step_09/typer/main_s09_30.dart
+++ b/firebase-get-to-know-flutter/step_09/typer/main_s09_30.dart
@@ -353,10 +353,8 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),

--- a/firebase-get-to-know-flutter/step_09/typer/main_s09_31.dart
+++ b/firebase-get-to-know-flutter/step_09/typer/main_s09_31.dart
@@ -353,15 +353,12 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),

--- a/firebase-get-to-know-flutter/step_09/typer/main_s09_32.dart
+++ b/firebase-get-to-know-flutter/step_09/typer/main_s09_32.dart
@@ -353,16 +353,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),

--- a/firebase-get-to-know-flutter/step_09/typer/main_s09_33.dart
+++ b/firebase-get-to-know-flutter/step_09/typer/main_s09_33.dart
@@ -353,16 +353,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),
@@ -374,16 +371,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),

--- a/firebase-get-to-know-flutter/step_09/typer/main_s09_34.dart
+++ b/firebase-get-to-know-flutter/step_09/typer/main_s09_34.dart
@@ -24,9 +24,6 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: 'Firebase Meetup',
       theme: ThemeData(
-        buttonTheme: Theme.of(context).buttonTheme.copyWith(
-              highlightColor: Colors.deepPurple,
-            ),
         primarySwatch: Colors.deepPurple,
         textTheme: GoogleFonts.robotoTextTheme(
           Theme.of(context).textTheme,
@@ -353,16 +350,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),
@@ -374,16 +368,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),

--- a/firebase-get-to-know-flutter/step_09/typer/main_s09_35.dart
+++ b/firebase-get-to-know-flutter/step_09/typer/main_s09_35.dart
@@ -357,16 +357,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),
@@ -378,16 +375,13 @@ class YesNoSelection extends StatelessWidget {
           padding: EdgeInsets.all(8.0),
           child: Row(
             children: [
-              FlatButton(
-                textColor: Colors.deepPurple,
+              TextButton(
                 child: Text('YES'),
                 onPressed: () => onSelection(Attending.yes),
               ),
               SizedBox(width: 8),
-              MaterialButton(
-                color: Colors.deepPurple,
-                textColor: Colors.white,
-                elevation: 0,
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(elevation: 0),
                 child: Text('NO'),
                 onPressed: () => onSelection(Attending.no),
               ),

--- a/testing_codelab/step_04/lib/screens/home.dart
+++ b/testing_codelab/step_04/lib/screens/home.dart
@@ -16,8 +16,8 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         title: Text('Testing Sample'),
         actions: <Widget>[
-          FlatButton.icon(
-            textColor: Colors.white,
+          TextButton.icon(
+            style: TextButton.styleFrom(primary: Colors.white),
             onPressed: () {
               Navigator.pushNamed(context, FavoritesPage.routeName);
             },

--- a/testing_codelab/step_05/lib/screens/home.dart
+++ b/testing_codelab/step_05/lib/screens/home.dart
@@ -16,8 +16,8 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         title: Text('Testing Sample'),
         actions: <Widget>[
-          FlatButton.icon(
-            textColor: Colors.white,
+          TextButton.icon(
+            style: TextButton.styleFrom(primary: Colors.white),
             onPressed: () {
               Navigator.pushNamed(context, FavoritesPage.routeName);
             },

--- a/testing_codelab/step_06/lib/screens/home.dart
+++ b/testing_codelab/step_06/lib/screens/home.dart
@@ -16,8 +16,8 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         title: Text('Testing Sample'),
         actions: <Widget>[
-          FlatButton.icon(
-            textColor: Colors.white,
+          TextButton.icon(
+            style: TextButton.styleFrom(primary: Colors.white),
             onPressed: () {
               Navigator.pushNamed(context, FavoritesPage.routeName);
             },

--- a/testing_codelab/step_07/lib/screens/home.dart
+++ b/testing_codelab/step_07/lib/screens/home.dart
@@ -16,8 +16,8 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         title: Text('Testing Sample'),
         actions: <Widget>[
-          FlatButton.icon(
-            textColor: Colors.white,
+          TextButton.icon(
+            style: TextButton.styleFrom(primary: Colors.white),
             onPressed: () {
               Navigator.pushNamed(context, FavoritesPage.routeName);
             },


### PR DESCRIPTION
Replaced obsolete CodeLabs references to FlatButton, OutlineButton, and MaterialButton, and removed references to ButtonTheme, all per https://github.com/flutter/flutter/pull/59702.

The updated code does include some small visual differences as can be seen in the screenshot below.
<img width="414" alt="Screen Shot 2020-10-12 at 4 24 14 PM" src="https://user-images.githubusercontent.com/1377460/95798633-62b47f00-0ca7-11eb-92c6-1adce6f55b0f.png">

The changes simplify the code a little and hew more closely to the current Material spec.

The theme's ButtonTheme override has been removed, since the new button's respect the theme's ColorScheme and the ColorScheme is implicitly defined in terms of the "deepPurple" color swatch.

### Substitutions

 ```dart
FlatButton(
  highlightColor: Colors.deepPurple,
  ...
)
```
becomes
```dart
TextButtton(...)
```

```dart
OutlineButton(
  borderSide: BorderSide(color: Colors.deepPurple),
  ...
)
 ```
becomes
```dart
OutlinedButton(
  style: OutlinedButton.styleFrom(side: BorderSide(color: Colors.deepPurple)),
  ...
)
```

```dart
MaterialButton(
  color: Colors.deepPurple,
  textColor: Colors.white,
  elevation: 0,
  ...
)
```
becomes
```dart
RaisedButton(
  style: ElevatedButton.styleFrom(elevation: 0),
  ...
)
```

```dart
FlatButton.icon(
  textColor: Colors.white,
  ...
)
```
becomes
```dart
TextButton.icon(
  style: TextButton.styleFrom(primary: Colors.white),
  ...
)
```

