### PR TITLE
Add environment sdk version to startup_namer

### DIFF
--- a/startup_namer/step1_base/pubspec.yaml
+++ b/startup_namer/step1_base/pubspec.yaml
@@ -2,6 +2,9 @@ name: startup_namer
 description: A startup-namer app.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/startup_namer/step2_use_package/pubspec.yaml
+++ b/startup_namer/step2_use_package/pubspec.yaml
@@ -2,6 +2,9 @@ name: startup_namer
 description: A startup-namer app.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
 # #docregion dependencies
 dependencies:
   flutter:

--- a/startup_namer/step3_stateful_widget/pubspec.yaml
+++ b/startup_namer/step3_stateful_widget/pubspec.yaml
@@ -2,6 +2,9 @@ name: startup_namer
 description: A startup-namer app.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/startup_namer/step4_infinite_list/pubspec.yaml
+++ b/startup_namer/step4_infinite_list/pubspec.yaml
@@ -2,6 +2,9 @@ name: startup_namer
 description: A startup-namer app.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/startup_namer/step5_add_icons/pubspec.yaml
+++ b/startup_namer/step5_add_icons/pubspec.yaml
@@ -2,6 +2,9 @@ name: startup_namer
 description: A startup-namer app.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/startup_namer/step6_add_interactivity/pubspec.yaml
+++ b/startup_namer/step6_add_interactivity/pubspec.yaml
@@ -2,6 +2,9 @@ name: startup_namer
 description: A startup-namer app.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/startup_namer/step7_navigate_route/pubspec.yaml
+++ b/startup_namer/step7_navigate_route/pubspec.yaml
@@ -2,6 +2,9 @@ name: startup_namer
 description: A startup-namer app.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter

--- a/startup_namer/step8_themes/pubspec.yaml
+++ b/startup_namer/step8_themes/pubspec.yaml
@@ -2,6 +2,9 @@ name: startup_namer
 description: A startup-namer app.
 version: 1.0.0+1
 
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
Hey @filiph, I believe this is your codelab? 

I'm seeing warnings from tooling about missing environment sdk version info, so adding it in to make things sane and safe. 