### PR TITLE
Bring back README files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-pubspec.lock
 .packages
 
 # */**/android

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ pubspec.lock
 # */**/ios
 # */**/.gitignore
 */**/.metadata
-*/**/README.md
 
 .dart_tool/
 firebase-get-to-know-flutter/step_04/typer/steps.json


### PR DESCRIPTION
README files can be used to document where the codelab is, amongst other uses.