### PR TITLE
Enable null safe codelabs

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -20,9 +20,9 @@ jobs:
           - flutter_version: dev
             allow_failure: true
           - flutter_version: beta
-            allow_failure: true
-          - flutter_version: stable
             allow_failure: false
+          - flutter_version: stable
+            allow_failure: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1


### PR DESCRIPTION
Temporarily move to beta being the required branch for PR submission. This will enable codelabs to move to Dart 2.12 as minimum supported SDK to turn on null safety.