### PR TITLE
Update drag_and_drop.dart

### DIFF
--- a/cookbook/lib/examples/drag_and_drop.dart
+++ b/cookbook/lib/examples/drag_and_drop.dart
@@ -141,7 +141,7 @@ class _ExampleDragAndDropState extends State<ExampleDragAndDrop>
   }) {
     return LongPressDraggable<Item>(
       data: item,
-      dragAnchor: DragAnchor.pointer,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
       feedback: DraggingListItem(
         dragKey: _draggableKey,
         photoProvider: item.imageProvider,


### PR DESCRIPTION
This updates the drag and drop codelab  to migrate it away from deprecated code.

Fixes https://github.com/flutter/flutter/issues/80552