### PR TITLE
Update README to point to new workshop URLs

### DIFF
--- a/dartpad_codelabs/README.md
+++ b/dartpad_codelabs/README.md
@@ -1,20 +1,20 @@
-# DartPad codelabs
+# DartPad workshops
 
-Codelabs in this directory are displayed using DartPad.
+Workshops in this directory are displayed using DartPad.
 
-## Open a codelab
+## Open a workshop
 
 - [Flutter example][flutter-webserver]
 - [Dart example][dart-webserver]
 
-Alternatively, these codelabs can be loaded from GitHub directly:
+Alternatively, these workshops can be loaded from GitHub directly:
 
 - [Dart example][flutter-github]
 - [Flutter example][dart-github]
 - [Getting started with Slivers][slivers]
 - [Inherted Widget][inherited-widget]
 
-## Deploying 
+## Deploying
 
 Configure the Firebase project you want to deploy to:
 
@@ -28,9 +28,9 @@ Run the deploy command to upload the files:
 firebase deploy
 ```
 
-[flutter-webserver]: https://dartpad.dev/codelabs.html?webserver=https://dartpad-workshops-io2021.web.app/example_flutter
-[dart-webserver]: https://dartpad.dev/codelabs.html?webserver=https://dartpad-workshops-io2021.web.app/example_dart
-[slivers]: https://dartpad.dev/codelabs.html?webserver=https://dartpad-workshops-io2021.web.app/getting_started_with_slivers
-[inherted-widget]: https://dartpad.dev/codelabs.html?webserver=https://dartpad-workshops-io2021.web.app/inherited_widget
-[flutter-github]: https://dartpad.dev/codelabs.html?gh_owner=flutter&gh_repo=codelabs&gh_ref=main&gh_path=dartpad_codelabs/src/example_dart
-[dart-github]: https://dartpad.dev/codelabs.html?gh_owner=flutter&gh_repo=codelabs&gh_ref=main&gh_path=dartpad_codelabs/src/example_flutter
+[flutter-webserver]: https://dartpad.dev/workshops.html?webserver=https://dartpad-workshops-io2021.web.app/example_flutter
+[dart-webserver]: https://dartpad.dev/workshops.html?webserver=https://dartpad-workshops-io2021.web.app/example_dart
+[slivers]: https://dartpad.dev/workshops.html?webserver=https://dartpad-workshops-io2021.web.app/getting_started_with_slivers
+[inherted-widget]: https://dartpad.dev/workshops.html?webserver=https://dartpad-workshops-io2021.web.app/inherited_widget
+[flutter-github]: https://dartpad.dev/workshops.html?gh_owner=flutter&gh_repo=codelabs&gh_ref=main&gh_path=dartpad_workshops/src/example_dart
+[dart-github]: https://dartpad.dev/workshops.html?gh_owner=flutter&gh_repo=codelabs&gh_ref=main&gh_path=dartpad_workshops/src/example_flutter


### PR DESCRIPTION
The URL recently changed from /codelabs.html to /workshops.html (https://github.com/dart-lang/dart-pad/pull/1843)