### PR TITLE
Updates DartPad null safety codelab based on feedback

### DIFF
--- a/dartpad_codelabs/src/null_safety_workshop/meta.yaml
+++ b/dartpad_codelabs/src/null_safety_workshop/meta.yaml
@@ -13,28 +13,30 @@ steps:
   - name: '4: The assertion operator'
     directory: step_04
     has_solution: true
-  - name: '5: Type promotion and definite assignment'
+  - name: '5: The required keyword'
     directory: step_05
     has_solution: true
-  - name: '6: Type promotion with checks'
+  - name: '6: Type promotion and definite assignment'
     directory: step_06
     has_solution: true
-  - name: '7: Type promotion with exceptions'
+  - name: '7: Type promotion with checks'
     directory: step_07
     has_solution: true
-  - name: "8: Object properties aren't promotable"
+  - name: '8: Type promotion with exceptions'
     directory: step_08
     has_solution: true
-  - name: '9: Another tricky object field example'
+  - name: "9: Object properties aren't promotable"
     directory: step_09
     has_solution: true
-  - name: '10: The late keyword'
+  - name: '10: Another tricky object field example'
     directory: step_10
     has_solution: true
-  - name: '11: Late circular references'
+  - name: '11: The late keyword'
     directory: step_11
     has_solution: true
-  - name: '12: Late and lazy'
+  - name: '12: Late circular references'
     directory: step_12
     has_solution: true
-
+  - name: '13: Late and lazy'
+    directory: step_13
+    has_solution: true

--- a/dartpad_codelabs/src/null_safety_workshop/step_04/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_04/snippet.dart
@@ -5,8 +5,8 @@ void main() {
   List<int?> listThatCouldHoldNulls = [2, null, 4];
 
   int a = couldBeNullButIsnt;
-  int b = listThatCouldHoldNulls.first!; // first item in the list
-  int c = couldReturnNullButDoesnt()!.abs(); // absolute value
+  int b = listThatCouldHoldNulls.first; // first item in the list
+  int c = couldReturnNullButDoesnt().abs(); // absolute value
 
   print('a is $a.');
   print('b is $b.');

--- a/dartpad_codelabs/src/null_safety_workshop/step_04/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_04/solution.dart
@@ -5,8 +5,8 @@ void main() {
   List<int?> listThatCouldHoldNulls = [2, null, 4];
 
   int a = couldBeNullButIsnt;
-  int b = listThatCouldHoldNulls.first; // first item in the list
-  int c = couldReturnNullButDoesnt().abs(); // absolute value
+  int b = listThatCouldHoldNulls.first!; // first item in the list
+  int c = couldReturnNullButDoesnt()!.abs(); // absolute value
 
   print('a is $a.');
   print('b is $b.');

--- a/dartpad_codelabs/src/null_safety_workshop/step_05/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_05/instructions.md
@@ -1,13 +1,57 @@
-# Type promotion
-With sound null safety, Dart’s flow analysis has been extended to take
-nullability into account. Nullable variables that can’t possibly contain null
-values are treated like non-nullable variables. This behavior is called type
-promotion.
+# The `required` keyword
+Dart's named parameters are, by default, optional. Consider a function declared
+like this:
 
-Dart’s type system can track where variables are assigned and read, and can
-verify that non-nullable fields are given values before any code tries to read
-from them. This process is called definite assignment.
+```dart
+void printThreeValues({
+  int? first,
+  int? second,
+  int? third,
+});
+```
+
+Other code in an app could invoke this function with any combination of its
+three parameters. 
+
+```dart
+printThreeValues();
+printThreeValues(second: 12);
+printThreeValues(first: 1, second: 4, third: 2);
+```
+
+Any parameters that aren't supplied are given a value of `null`. Since the
+function uses nullable types (`int?`), this isn't a problem. What do you do,
+though, if you want to declare a function with named parameters of non-nullable
+types? Use the required keyword!
+
+```dart
+void printThreeValues({
+  required int first,
+  required int second,
+  required int third,
+});
+```
+
+When declared that way, all three of the parameters for `printThreeValues` are
+required, and any code that calls the function must provide all three -- 
+otherwise, it's a compile-time error.
+
+That means that this example from earlier would still work:
+
+```dart
+printThreeValues(first: 1, second: 4, third: 2);
+```
+
+The two, though, wouldn't:
+
+```dart
+printThreeValues();
+printThreeValues(second: 12);
+```
+
+By marking non-nullable named parameters required, you can make sure anyone
+calling a method provides a non-null value, maintaining sound null safety.
 
 ## Exercise
-Try uncommenting the if-else statement in the code below, and watch the analyzer
-errors disappear:
+Try correcting the errors in the code below by adding `required` to the right
+parameters.

--- a/dartpad_codelabs/src/null_safety_workshop/step_05/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_05/instructions.md
@@ -22,7 +22,7 @@ printThreeValues(first: 1, second: 4, third: 2);
 Any parameters that aren't supplied are given a value of `null`. Since the
 function uses nullable types (`int?`), this isn't a problem. What do you do,
 though, if you want to declare a function with named parameters of non-nullable
-types? Use the required keyword!
+types? Use the `required` keyword!
 
 ```dart
 void printThreeValues({
@@ -32,9 +32,9 @@ void printThreeValues({
 });
 ```
 
-When declared that way, all three of the parameters for `printThreeValues` are
-required, and any code that calls the function must provide all three -- 
-otherwise, it's a compile-time error.
+When declared this way, all three of the parameters for `printThreeValues` are
+required, and any code that calls the function must provide all three.
+Otherwise, it's a compile-time error.
 
 That means that this example from earlier would still work:
 

--- a/dartpad_codelabs/src/null_safety_workshop/step_05/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_05/snippet.dart
@@ -1,25 +1,17 @@
-void printThreeValues({
+int addThreeValues({
   int first,
   int second,
   int third,
 }) {
-  print('First is $first, second is $second, '
-  	  'and third is $third.');
-}
-
-void printFourValues({
-  int? first,
-  int second,
-  int? third,
-  int fourth
-}) {
-  print('First is $first, second is $second, '
-  	  'third is $third, and fourth is $fourth.');
+  return first + second + third;
 }
 
 void main() {
-  printThreeValues(first: 1, second: 2, third: 3);
-  printFourValues(first: 1, second: 2, third: 3,
-  	  fourth: 4);
-}
+  final sum = addThreeValues(
+    first: 2,
+    second: 5,
+    third: 3,
+  );
 
+  print(sum);
+}

--- a/dartpad_codelabs/src/null_safety_workshop/step_05/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_05/snippet.dart
@@ -1,12 +1,25 @@
-void main() {
-  String text;
-
-  // if (DateTime.now().hour < 12) {
-  //  text = "It's morning! Let's make aloo paratha!";
-  // } else {
-  //  text = "It's afternoon! Let's make biryani!";
-  // }
-
-  print(text);
-  print(text.length);
+void printThreeValues({
+  int first,
+  int second,
+  int third,
+}) {
+  print('First is $first, second is $second, '
+  	  'and third is $third.');
 }
+
+void printFourValues({
+  int? first,
+  int second,
+  int? third,
+  int fourth
+}) {
+  print('First is $first, second is $second, '
+  	  'third is $third, and fourth is $fourth.');
+}
+
+void main() {
+  printThreeValues(first: 1, second: 2, third: 3);
+  printFourValues(first: 1, second: 2, third: 3,
+  	  fourth: 4);
+}
+

--- a/dartpad_codelabs/src/null_safety_workshop/step_05/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_05/solution.dart
@@ -1,12 +1,24 @@
+void printThreeValues({
+  required int first,
+  required int second,
+  required int third,
+}) {
+  print('First is $first, second is $second, '
+  	  'and third is $third.');
+}
+
+void printFourValues({
+  int? first,
+  required int second,
+  int? third,
+  required int fourth
+}) {
+  print('First is $first, second is $second, '
+  	  'third is $third, and fourth is $fourth.');
+}
+
 void main() {
-  String text;
-
-  if (DateTime.now().hour < 12) {
-    text = "It's morning! Let's make aloo paratha!";
-  } else {
-    text = "It's afternoon! Let's make biryani!";
-  }
-
-  print(text);
-  print(text.length);
+  printThreeValues(first: 1, second: 2, third: 3);
+  printFourValues(first: 1, second: 2, third: 3,
+  	  fourth: 4);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_05/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_05/solution.dart
@@ -1,24 +1,17 @@
-void printThreeValues({
+int addThreeValues({
   required int first,
   required int second,
   required int third,
 }) {
-  print('First is $first, second is $second, '
-  	  'and third is $third.');
-}
-
-void printFourValues({
-  int? first,
-  required int second,
-  int? third,
-  required int fourth
-}) {
-  print('First is $first, second is $second, '
-  	  'third is $third, and fourth is $fourth.');
+  return first + second + third;
 }
 
 void main() {
-  printThreeValues(first: 1, second: 2, third: 3);
-  printFourValues(first: 1, second: 2, third: 3,
-  	  fourth: 4);
+  final sum = addThreeValues(
+    first: 2,
+    second: 5,
+    third: 3,
+  );
+
+  print(sum);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_06/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_06/instructions.md
@@ -1,7 +1,13 @@
-# Type promotion via null checks
-Dart can also promote nullable variables to non-nullable ones when there's a
-null check in the same scope.
+# Type promotion
+With sound null safety, Dart’s flow analysis has been extended to take
+nullability into account. Nullable variables that can’t possibly contain null
+values are treated like non-nullable variables. This behavior is called type
+promotion.
+
+Dart’s type system can track where variables are assigned and read, and can
+verify that non-nullable fields are given values before any code tries to read
+from them. This process is called definite assignment.
 
 ## Exercise
-In the code below, add an `if` statement to the beginning of `getLength` that
-returns zero if `str` is null:
+Try uncommenting the if-else statement in the code below, and watch the analyzer
+errors disappear:

--- a/dartpad_codelabs/src/null_safety_workshop/step_06/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_06/snippet.dart
@@ -1,9 +1,12 @@
-int getLength(String? str) {
-  // Add null check here
-
-  return str.length;
-}
-
 void main() {
-  print(getLength('This is a string!'));
+  String text;
+
+  // if (DateTime.now().hour < 12) {
+  //  text = "It's morning! Let's make aloo paratha!";
+  // } else {
+  //  text = "It's afternoon! Let's make biryani!";
+  // }
+
+  print(text);
+  print(text.length);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_06/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_06/snippet.dart
@@ -1,5 +1,5 @@
 void main() {
-  String text;
+  String? text;
 
   // if (DateTime.now().hour < 12) {
   //  text = "It's morning! Let's make aloo paratha!";

--- a/dartpad_codelabs/src/null_safety_workshop/step_06/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_06/solution.dart
@@ -1,11 +1,12 @@
-int getLength(String? str) {
-  if (str == null) {
-  	return 0;
+void main() {
+  String text;
+
+  if (DateTime.now().hour < 12) {
+    text = "It's morning! Let's make aloo paratha!";
+  } else {
+    text = "It's afternoon! Let's make biryani!";
   }
 
-  return str.length;
-}
-
-void main() {
-  print(getLength('This is a string!'));
+  print(text);
+  print(text.length);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_06/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_06/solution.dart
@@ -1,5 +1,5 @@
 void main() {
-  String text;
+  String? text;
 
   if (DateTime.now().hour < 12) {
     text = "It's morning! Let's make aloo paratha!";

--- a/dartpad_codelabs/src/null_safety_workshop/step_07/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_07/instructions.md
@@ -1,7 +1,7 @@
-# Promotion via exceptions
-Promotion works with exceptions as well as return statements. If you check a
-nullable variable for null and throw an exception, Dart will consider any future
-reads from that variable in the same scope to be null-safe.
+# Type promotion via null checks
+Dart can also promote nullable variables to non-nullable ones when there's a
+null check in the same scope.
 
 ## Exercise
-Try a null check that throws an Exception instead of returning zero.
+In the code below, add an `if` statement to the beginning of `getLength` that
+returns zero if `str` is null:

--- a/dartpad_codelabs/src/null_safety_workshop/step_07/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_07/snippet.dart
@@ -1,9 +1,9 @@
 int getLength(String? str) {
-  // Try throwing an exception here if `str` is null.
+  // Add null check here
 
   return str.length;
 }
 
 void main() {
-  print(getLength(null));
+  print(getLength('This is a string!'));
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_07/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_07/solution.dart
@@ -1,11 +1,11 @@
 int getLength(String? str) {
   if (str == null) {
-    throw Exception('The value is null!');
+  	return 0;
   }
 
   return str.length;
 }
 
 void main() {
-  print(getLength(null));
+  print(getLength('This is a string!'));
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_08/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_08/instructions.md
@@ -1,13 +1,7 @@
-# Object properties aren't promotable
-A common "Huh?" moment when first learning to use Dart's null safety arrives the
-first time you do a null check on an object field. This is due to the fact that
-in Dart, object properties have getters and setters (either real or implied),
-and so something that looks like a typical value property can return different
-things when read twice in the same code block.
+# Promotion via exceptions
+Promotion works with exceptions as well as return statements. If you check a
+nullable variable for null and throw an exception, Dart will consider any future
+reads from that variable in the same scope to be null-safe.
 
-Fortunately, there's a simple trick to handle this: read the variable once and
-cache it in a local variable@
-
-## Exercise: 
-Try adding a local variable to store the value returned by `provider.value` in
-the example, then check and print that variable instead.
+## Exercise
+Try a null check that throws an Exception instead of returning zero.

--- a/dartpad_codelabs/src/null_safety_workshop/step_08/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_08/snippet.dart
@@ -1,18 +1,9 @@
-import 'dart:math';
+int getLength(String? str) {
+  // Try throwing an exception here if `str` is null.
 
-class RandomStringProvider {
-  String? get value =>
-    Random().nextBool() ? 'A String!' : null;
+  return str.length;
 }
 
-void printString(String str) => print(str);
-
 void main() {
-  final provider = RandomStringProvider();
-
-  if (provider.value == null) {
-    print('The value is null.');
-  }
-
-  printString(provider.value);
+  print(getLength(null));
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_08/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_08/solution.dart
@@ -1,20 +1,11 @@
-import 'dart:math';
-
-class RandomStringProvider {
-  String? get value =>
-    Random().nextBool() ? 'A String!' : null;
-}
-
-void printString(String str) => print(str);
-
-void main() {
-  final provider = RandomStringProvider();
-
-  final str = provider.value;
-
+int getLength(String? str) {
   if (str == null) {
-    print('The value is null.');
+    throw Exception('The value is null!');
   }
 
-  printString(str);
+  return str.length;
+}
+
+void main() {
+  print(getLength(null));
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_09/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_09/instructions.md
@@ -1,14 +1,13 @@
-# Another tricky object property example
-Even if a class doesn't define a getter for its property, it's possible for a
-subclass to implement one anyway. In this case, what looks like a
-straightforward property in `StringProvider` gets turned into a random value in
-`RandomStringProvider`.
+# Object properties aren't promotable
+A common "Huh?" moment when first learning to use Dart's null safety arrives the
+first time you do a null check on an object field. This is due to the fact that
+in Dart, object properties have getters and setters (either real or implied),
+and so something that looks like a typical value property can return different
+things when read twice in the same code block.
 
-When the code in `main` goes to access the value, even though `provider` is
-typed as `StringProvider`, it's holding a `RandomStringProvider`, illustrating
-why the value can't easily be promoted.
+Fortunately, there's a simple trick to handle this: read the variable once and
+cache it in a local variable@
 
 ## Exercise: 
-This exercise is really just an illustration of how overridable getters affect
-null safety, but it can be solved the same way as the previous one: by caching
-the value of the `provider.value` in a local variable.
+Try adding a local variable to store the value returned by `provider.value` in
+the example, then check and print that variable instead.

--- a/dartpad_codelabs/src/null_safety_workshop/step_09/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_09/snippet.dart
@@ -1,14 +1,6 @@
 import 'dart:math';
 
-class StringProvider {
-  String? value = 'A String!';
-}
-
-class RandomStringProvider extends StringProvider {
-  @override
-  void set value(String? v) {}
-
-  @override
+class RandomStringProvider {
   String? get value =>
     Random().nextBool() ? 'A String!' : null;
 }
@@ -16,7 +8,7 @@ class RandomStringProvider extends StringProvider {
 void printString(String str) => print(str);
 
 void main() {
-  StringProvider provider = RandomStringProvider();
+  final provider = RandomStringProvider();
 
   if (provider.value == null) {
     print('The value is null.');

--- a/dartpad_codelabs/src/null_safety_workshop/step_09/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_09/snippet.dart
@@ -12,6 +12,8 @@ void main() {
 
   if (provider.value == null) {
     print('The value is null.');
+  } else {
+    print('The value is not null.');
   }
 
   printString(provider.value);

--- a/dartpad_codelabs/src/null_safety_workshop/step_09/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_09/solution.dart
@@ -14,6 +14,8 @@ void main() {
 
   if (str == null) {
     print('The value is null.');
+  } else {
+    print('The value is not null.');
   }
 
   printString(str);

--- a/dartpad_codelabs/src/null_safety_workshop/step_09/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_09/solution.dart
@@ -1,14 +1,6 @@
 import 'dart:math';
 
-class StringProvider {
-  String? value = 'A String!';
-}
-
-class RandomStringProvider extends StringProvider {
-  @override
-  void set value(String? v) {}
-
-  @override
+class RandomStringProvider {
   String? get value =>
     Random().nextBool() ? 'A String!' : null;
 }
@@ -16,7 +8,7 @@ class RandomStringProvider extends StringProvider {
 void printString(String str) => print(str);
 
 void main() {
-  StringProvider provider = RandomStringProvider();
+  final provider = RandomStringProvider();
 
   final str = provider.value;
 

--- a/dartpad_codelabs/src/null_safety_workshop/step_10/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_10/instructions.md
@@ -1,18 +1,14 @@
-# The late keyword
-Sometimes variables — fields in a class, or top-level variables — _should_ be
-non-nullable, but they can’t be assigned a value immediately. For cases like
-that, use the `late` keyword.
+# Another tricky object property example
+Even if a class doesn't define a getter for its property, it's possible for a
+subclass to implement one anyway. In this case, what looks like a
+straightforward property in `StringProvider` gets turned into a random value in
+`RandomStringProvider`.
 
-When you put `late` in front of a variable declaration, that tells Dart the
-following:
+When the code in `main` goes to access the value, even though `provider` is
+typed as `StringProvider`, it's holding a `RandomStringProvider`, illustrating
+why the value can't easily be promoted.
 
-* Don’t assign that variable a value yet.
-* You will assign it a value later.
-* You’ll make sure that the variable has a value before the variable is used.
-
-Be wary, though -- if you declare a variable late and that variable is read
-before it’s assigned a value, an error is thrown.
-
-## Exercise
-Try using the `late` keyword to correct the following code. For a little extra
-fun afterward, try commenting out the line that sets description!
+## Exercise: 
+This exercise is really just an illustration of how overridable getters affect
+null safety, but it can be solved the same way as the previous one: by caching
+the value of the `provider.value` in a local variable.

--- a/dartpad_codelabs/src/null_safety_workshop/step_10/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_10/snippet.dart
@@ -1,13 +1,26 @@
-class Meal {
-  String description;
+import 'dart:math';
 
-  void setDescription(String str) {
-    description = str;
-  }
+class StringProvider {
+  String? value = 'A String!';
 }
 
+class RandomStringProvider extends StringProvider {
+  @override
+  void set value(String? v) {}
+
+  @override
+  String? get value =>
+    Random().nextBool() ? 'A String!' : null;
+}
+
+void printString(String str) => print(str);
+
 void main() {
-  final myMeal = Meal();
-  myMeal.setDescription('Feijoada!');
-  print(myMeal.description);
+  StringProvider provider = RandomStringProvider();
+
+  if (provider.value == null) {
+    print('The value is null.');
+  }
+
+  printString(provider.value);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_10/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_10/snippet.dart
@@ -20,6 +20,7 @@ void main() {
 
   if (provider.value == null) {
     print('The value is null.');
+    return;
   }
 
   printString(provider.value);

--- a/dartpad_codelabs/src/null_safety_workshop/step_10/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_10/solution.dart
@@ -18,11 +18,14 @@ void printString(String str) => print(str);
 void main() {
   StringProvider provider = RandomStringProvider();
 
-  final str = provider.value;
+  final value = provider.value;
 
-  if (str == null) {
+  if (value == null) {
     print('The value is null.');
+    return;
+  } else {
+    print('The value is not null, so print it!');
   }
 
-  printString(str);
+  printString(value);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_10/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_10/solution.dart
@@ -1,13 +1,28 @@
-class Meal {
-  late String description;
+import 'dart:math';
 
-  void setDescription(String str) {
-    description = str;
-  }
+class StringProvider {
+  String? value = 'A String!';
 }
 
+class RandomStringProvider extends StringProvider {
+  @override
+  void set value(String? v) {}
+
+  @override
+  String? get value =>
+    Random().nextBool() ? 'A String!' : null;
+}
+
+void printString(String str) => print(str);
+
 void main() {
-  final myMeal = Meal();
-  myMeal.setDescription('Feijoada!');
-  print(myMeal.description);
+  StringProvider provider = RandomStringProvider();
+
+  final str = provider.value;
+
+  if (str == null) {
+    print('The value is null.');
+  }
+
+  printString(str);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_11/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_11/instructions.md
@@ -1,9 +1,18 @@
-# An advanced pattern: late circular references
-The `late` keyword is helpful for tricky patterns like circular references. This
-code has two objects that need to maintain non-nullable references to each
-other.
+# The late keyword
+Sometimes variables — fields in a class, or top-level variables — _should_ be
+non-nullable, but they can’t be assigned a value immediately. For cases like
+that, use the `late` keyword.
+
+When you put `late` in front of a variable declaration, that tells Dart the
+following:
+
+* Don’t assign that variable a value yet.
+* You will assign it a value later.
+* You’ll make sure that the variable has a value before the variable is used.
+
+Be wary, though -- if you declare a variable late and that variable is read
+before it’s assigned a value, an error is thrown.
 
 ## Exercise
-Try using the `late` keyword to fix this code.
-
-_(Note that you don’t need to remove final. You can create late final variables: you set their values once, and after that they’re read-only.)_
+Try using the `late` keyword to correct the following code. For a little extra
+fun afterward, try commenting out the line that sets description!

--- a/dartpad_codelabs/src/null_safety_workshop/step_11/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_11/snippet.dart
@@ -1,16 +1,13 @@
-class Team {
-  final Coach coach;
-}
+class Meal {
+  String description;
 
-class Coach {
-  final Team team;
+  void setDescription(String str) {
+    description = str;
+  }
 }
 
 void main() {
-  final myTeam = Team();
-  final myCoach = Coach();
-  myTeam.coach = myCoach;
-  myCoach.team = myTeam;
-
-  print('All done!');
+  final myMeal = Meal();
+  myMeal.setDescription('Feijoada!');
+  print(myMeal.description);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_11/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_11/solution.dart
@@ -1,16 +1,13 @@
-class Team {
-  late final Coach coach;
-}
+class Meal {
+  late String description;
 
-class Coach {
-  late final Team team;
+  void setDescription(String str) {
+    description = str;
+  }
 }
 
 void main() {
-  final myTeam = Team();
-  final myCoach = Coach();
-  myTeam.coach = myCoach;
-  myCoach.team = myTeam;
-
-  print('All done!');
+  final myMeal = Meal();
+  myMeal.setDescription('Feijoada!');
+  print(myMeal.description);
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_12/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_12/instructions.md
@@ -1,10 +1,9 @@
-# Late and lazy
-Another pattern that `late` can help with is lazy initialization for expensive,
-non-nullable fields. 
+# An advanced pattern: late circular references
+The `late` keyword is helpful for tricky patterns like circular references. This
+code has two objects that need to maintain non-nullable references to each
+other.
 
 ## Exercise
-Try this:
+Try using the `late` keyword to fix this code.
 
-* Run this code without changing it, and note the output.
-* Think: What will change if you make _cache a late field?
-* Make _cache a late field, and run the code. Was your prediction correct?
+_(Note that you don’t need to remove final. You can create late final variables: you set their values once, and after that they’re read-only.)_

--- a/dartpad_codelabs/src/null_safety_workshop/step_12/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_12/snippet.dart
@@ -1,16 +1,16 @@
-int _computeValue() {
-  print('In _computeValue...');
-  return 3;
+class Team {
+  final Coach coach;
 }
 
-class CachedValueProvider {
-  final _cache = _computeValue();
-  int get value => _cache;
+class Coach {
+  final Team team;
 }
 
 void main() {
-  print('Calling constructor...');
-  var provider = CachedValueProvider();
-  print('Getting value...');
-  print('The value is ${provider.value}!');
+  final myTeam = Team();
+  final myCoach = Coach();
+  myTeam.coach = myCoach;
+  myCoach.team = myTeam;
+
+  print('All done!');
 }

--- a/dartpad_codelabs/src/null_safety_workshop/step_12/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_12/solution.dart
@@ -1,15 +1,16 @@
-int _computeValue() {
-  print('In _computeValue...');
-  return 3;
+class Team {
+  late final Coach coach;
 }
 
-class CachedValueProvider {
-  late final _cache = _computeValue();
-  int get value => _cache;
+class Coach {
+  late final Team team;
 }
 
 void main() {
-  print('Calling constructor...');
-  var provider = CachedValueProvider();
-  print('Getting value...');
-  print('The value is ${provider.value}!');
+  final myTeam = Team();
+  final myCoach = Coach();
+  myTeam.coach = myCoach;
+  myCoach.team = myTeam;
+
+  print('All done!');
+}

--- a/dartpad_codelabs/src/null_safety_workshop/step_13/instructions.md
+++ b/dartpad_codelabs/src/null_safety_workshop/step_13/instructions.md
@@ -1,0 +1,10 @@
+# Late and lazy
+Another pattern that `late` can help with is lazy initialization for expensive,
+non-nullable fields. 
+
+## Exercise
+Try this:
+
+* Run this code without changing it, and note the output.
+* Think: What will change if you make _cache a late field?
+* Make _cache a late field, and run the code. Was your prediction correct?

--- a/dartpad_codelabs/src/null_safety_workshop/step_13/snippet.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_13/snippet.dart
@@ -1,0 +1,16 @@
+int _computeValue() {
+  print('In _computeValue...');
+  return 3;
+}
+
+class CachedValueProvider {
+  final _cache = _computeValue();
+  int get value => _cache;
+}
+
+void main() {
+  print('Calling constructor...');
+  var provider = CachedValueProvider();
+  print('Getting value...');
+  print('The value is ${provider.value}!');
+}

--- a/dartpad_codelabs/src/null_safety_workshop/step_13/solution.dart
+++ b/dartpad_codelabs/src/null_safety_workshop/step_13/solution.dart
@@ -1,0 +1,15 @@
+int _computeValue() {
+  print('In _computeValue...');
+  return 3;
+}
+
+class CachedValueProvider {
+  late final _cache = _computeValue();
+  int get value => _cache;
+}
+
+void main() {
+  print('Calling constructor...');
+  var provider = CachedValueProvider();
+  print('Getting value...');
+  print('The value is ${provider.value}!');


### PR DESCRIPTION
Updates the exercises for the null safety codelab based on today's feedback. There's some unfortunate churn here as well, since adding the `required` keyword step bumped a whole bunch of stuff down a step.