### PR TITLE
Use code blocks in inherited widget codelab

### DIFF
--- a/dartpad_codelabs/src/inherited_widget/intro/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/intro/instructions.md
@@ -1,7 +1,7 @@
 # Introduction
 
 State management is an important topic in mobile development.
-In Flutter, <span style="font-family: 'Courier New';">InheritedWidget</span> makes the process of building
+In Flutter, `InheritedWidget` makes the process of building
 the state management system easier. In this workshop,
 you will learn how to handle your app state by using InheritedWidget.
 
@@ -19,7 +19,7 @@ click the **Run** button in the top, right corner of the IDE.
 Try to scroll through different google products, and add or remove products from
 the cart. The small cart icon on the right side of the app bar changes based on number
 of products in the cart. You can also perform search queries by clicking the
-search icon in the app bar and typing <span style="font-family: 'Courier New';">nest</span> to filter nest products.
+search icon in the app bar and typing `nest` to filter nest products.
 
 There are two components that require stateful objects:
 

--- a/dartpad_codelabs/src/inherited_widget/step_01/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_01/instructions.md
@@ -5,12 +5,12 @@ To do that, we must determine what’s considered to be the app’s state.
 
 We know there are at least two components that require state: the product list and the cart icon.
 
-In the source code, the product list corresponds to the <span style="font-family: 'Courier New';">ProductListWidget</span>,
-and the cart icon corresponds to the <span style="font-family: 'Courier New';">ShoppingCartIcon</span>.
+In the source code, the product list corresponds to the `ProductListWidget`,
+and the cart icon corresponds to the `ShoppingCartIcon`.
 
-Let's look at the <span style="font-family: 'Courier New';">ProductListWidget</span> widget first. This widget builds the
+Let's look at the `ProductListWidget` widget first. This widget builds the
 scrollable body and displays Google products.  Because the widget needs to know which products to display and which products are already in the cart, the
-<span style="font-family: 'Courier New';">ProductListState</span> stores the <span style="font-family: 'Courier New';">productList</span> and the <span style="font-family: 'Courier New';">itemsInCart</span>.
+`ProductListState` stores the `productList` and the `itemsInCart`.
 
 ```dart
 class ProductListWidgetState extends State<ProductListWidget> {
@@ -34,7 +34,7 @@ class ProductListWidgetState extends State<ProductListWidget> {
 }
 ```
 
-On the other hand, the <span style="font-family: 'Courier New';">ShoppingCartIcon</span> also stores <span style="font-family: 'Courier New';">itemsInCart</span> because
+On the other hand, the `ShoppingCartIcon` also stores `itemsInCart` because
 it needs to know number of products that are in the cart.
 
 ```dart
@@ -51,14 +51,14 @@ class ShoppingCartIconState extends State<ShoppingCartIcon> {
 }
 ```
 
-This is where things get interesting. Both <span style="font-family: 'Courier New';">ShoppingCartIcon</span> and <span style="font-family: 'Courier New';">ProductListWidget</span> store their own
-versions of <span style="font-family: 'Courier New';">itemsInCart</span>, and the <span style="font-family: 'Courier New';">itemsInCart</span> must be kept in sync. When the <span style="font-family: 'Courier New';">itemsInCart</span> is updated
-in the <span style="font-family: 'Courier New';">ProductListWidget</span>, the <span style="font-family: 'Courier New';">ProductListWidget</span> also needs to update the <span style="font-family: 'Courier New';">itemsInCart</span> in the <span style="font-family: 'Courier New';">ShoppingCartIcon</span>. Things can
-can get out of hand very quickly if we added more widgets that depends on the <span style="font-family: 'Courier New';">itemsInCart</span>.
+This is where things get interesting. Both `ShoppingCartIcon` and `ProductListWidget` store their own
+versions of `itemsInCart`, and the `itemsInCart` must be kept in sync. When the `itemsInCart` is updated
+in the `ProductListWidget`, the `ProductListWidget` also needs to update the `itemsInCart` in the `ShoppingCartIcon`. Things can
+can get out of hand very quickly if we added more widgets that depends on the `itemsInCart`.
 
 Now, let's pull these states out of the widgets.
 
-You can find the class by searching for <span style="font-family: 'Courier New';">TODO</span> in the IDE
+You can find the class by searching for `TODO` in the IDE
 
 ```dart
 class AppState {

--- a/dartpad_codelabs/src/inherited_widget/step_02/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_02/instructions.md
@@ -3,10 +3,10 @@
 Now, we have our own data structure to store the states. The next thing we want to do is to place
 the data above the widgets that need it, so the entire widget subtree has access to the data.
 
-This is where the <span style="font-family: 'Courier New';">InheritedWidget</span> comes in handy. The widget has the ability
+This is where the `InheritedWidget` comes in handy. The widget has the ability
 to host the data for the subtree and notify the subtree to rebuild when the data changes.
 
-The next step is to create our own <span style="font-family: 'Courier New';">InheritedWidget</span> to host the data.
+The next step is to create our own `InheritedWidget` to host the data.
 
 ```dart
 class AppStateScope extends InheritedWidget {

--- a/dartpad_codelabs/src/inherited_widget/step_03/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_03/instructions.md
@@ -1,10 +1,10 @@
 # Create a StatefulWidget around the AppStateScope
 
-The <span style="font-family: 'Courier New';">AppStateScope</span> doesn't have state, it only hosts the data
-that it receives. We still need to create a <span style="font-family: 'Courier New';">StatefulWidget</span> to store
-the data. The goal of this <span style="font-family: 'Courier New';">StatefulWidget</span> is to create the <span style="font-family: 'Courier New';">AppState</span>
+The `AppStateScope` doesn't have state, it only hosts the data
+that it receives. We still need to create a `StatefulWidget` to store
+the data. The goal of this `StatefulWidget` is to create the `AppState`
 , provide APIs to modify the data, and host the data using the
-<span style="font-family: 'Courier New';">AppStateScope</span>.
+`AppStateScope`.
 
 ```dart
 class AppStateWidget extends StatefulWidget {

--- a/dartpad_codelabs/src/inherited_widget/step_04/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_04/instructions.md
@@ -1,6 +1,6 @@
 # Insert the AppStateWidget into the widget tree
 
-Now, we’ll insert the <span style="font-family: 'Courier New';">AppStateWidgetState</span> into the widget tree.
+Now, we’ll insert the `AppStateWidgetState` into the widget tree.
 
 ```dart
 void main() {

--- a/dartpad_codelabs/src/inherited_widget/step_05/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_05/instructions.md
@@ -1,7 +1,7 @@
 # Migrate the ShoppingCartIcon
 
-Every widget should have access to the <span style="font-family: 'Courier New';">AppStateWidget</span> and <span style="font-family: 'Courier New';">AppStateScope</span>.
-Let's migrate the <span style="font-family: 'Courier New';">ShoppingCartIcon</span> so that it uses <span style="font-family: 'Courier New';">AppStateScope</span> instead of storing
+Every widget should have access to the `AppStateWidget` and `AppStateScope`.
+Let's migrate the `ShoppingCartIcon` so that it uses `AppStateScope` instead of storing
 the state locally.
 
 **Note:** The app won’t work properly until we migrate all the widgets.

--- a/dartpad_codelabs/src/inherited_widget/step_06/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_06/instructions.md
@@ -1,6 +1,6 @@
 # Migrate the ProductListWidget
 
-Let's do the same thing for the <span style="font-family: 'Courier New';">ProductListWidget</span> so that it also uses <span style="font-family: 'Courier New';">AppStateScope</span>.
+Let's do the same thing for the `ProductListWidget` so that it also uses `AppStateScope`.
 
 ```dart
 // TODO: convert ProductListWidget into StatelessWidget.

--- a/dartpad_codelabs/src/inherited_widget/step_07/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_07/instructions.md
@@ -1,6 +1,6 @@
 # Migrate search TextField
 
-We also need to migrate the search query so that it updates the <span style="font-family: 'Courier New';">AppState</span>.
+We also need to migrate the search query so that it updates the `AppState`.
 
 ```dart
   void _toggleSearch() {

--- a/dartpad_codelabs/src/inherited_widget/step_08/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_08/instructions.md
@@ -1,10 +1,10 @@
 # Migrate MyStorePage
 
 We successfully migrated the app to use a centralized state management system.
-However, there's still one <span style="font-family: 'Courier New';">StatefulWidget</span> that contains its own state. That widget is
-<span style="font-family: 'Courier New';">MyStorePage</span>.
+However, there's still one `StatefulWidget` that contains its own state. That widget is
+`MyStorePage`.
 
-The <span style="font-family: 'Courier New';">MyStorePage</span> widget keeps track of whether it's in search mode and any <span style="font-family: 'Courier New';">TextField</span>-related
+The `MyStorePage` widget keeps track of whether it's in search mode and any `TextField`-related
 controllers. For the purpose of this workshop, let's see if we can completely eliminate
 any state hanging around the app.
 

--- a/dartpad_codelabs/src/inherited_widget/step_09/instructions.md
+++ b/dartpad_codelabs/src/inherited_widget/step_09/instructions.md
@@ -2,7 +2,7 @@
 
 Congratulations! You successfully completed this workshop!
 
-To learn more about <span style="font-family: 'Courier New';">InheritedWidget</span>, visit the
+To learn more about `InheritedWidget`, visit the
 [Flutter API document for InheritedWidget](https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html) or
 the [Flutter Widget 101 for InheritedWidget](https://www.youtube.com/watch?v=Zbm3hjPjQMk)
 


### PR DESCRIPTION
Code block appearance is been improved in DartPad now:

https://github.com/dart-lang/dart-pad/pull/1890

<img width="474" alt="Screen Shot 2021-05-14 at 11 19 18 AM" src="https://user-images.githubusercontent.com/1145719/118312895-ee44f700-b4a6-11eb-8767-b5f3b5d0f7c4.png">
