### PR TITLE
Fix gradient_bubbles.dart

### DIFF
--- a/cookbook/lib/examples/gradient_bubbles.dart
+++ b/cookbook/lib/examples/gradient_bubbles.dart
@@ -145,7 +145,8 @@ class BubblePainter extends CustomPainter {
     required List<Color> colors,
   })   : _scrollable = scrollable,
         _bubbleContext = bubbleContext,
-        _colors = colors;
+        _colors = colors,
+        super(repaint: scrollable.position);
 
   final ScrollableState _scrollable;
   final BuildContext _bubbleContext;


### PR DESCRIPTION
The painter doesn’t repaint every time the scroll position changes.
We must pass the ScrollableState’s ScrollPosition to the CustomPainter superclass so that the CustomPainter repaints every time the ScrollPosition changes.