### PR TITLE
Update iap version to stable

### DIFF
--- a/in_app_purchases/complete/app/pubspec.lock
+++ b/in_app_purchases/complete/app/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -260,7 +260,7 @@ packages:
       name: in_app_purchase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0"
+    version: "1.0.0"
   in_app_purchase_android:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -461,7 +461,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -496,21 +496,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.5"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.15"
+    version: "0.3.19"
   typed_data:
     dependency: transitive
     description:

--- a/in_app_purchases/complete/app/pubspec.yaml
+++ b/in_app_purchases/complete/app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   cloud_functions: "^1.0.3"
   cloud_firestore: "^1.0.4"
   google_sign_in: "^5.0.1"
-  in_app_purchase: "^0.6.0"
+  in_app_purchase: "^1.0.0"
 
 
   flutter:

--- a/in_app_purchases/step_00/app/pubspec.lock
+++ b/in_app_purchases/step_00/app/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -265,7 +265,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -300,7 +300,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/in_app_purchases/step_06/app/pubspec.lock
+++ b/in_app_purchases/step_06/app/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -260,7 +260,7 @@ packages:
       name: in_app_purchase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0"
+    version: "1.0.0"
   in_app_purchase_android:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -461,7 +461,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -496,21 +496,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.5"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.15"
+    version: "0.3.19"
   typed_data:
     dependency: transitive
     description:

--- a/in_app_purchases/step_06/app/pubspec.yaml
+++ b/in_app_purchases/step_06/app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   cloud_functions: "^1.0.3"
   cloud_firestore: "^1.0.4"
   google_sign_in: "^5.0.1"
-  in_app_purchase: "^0.6.0"
+  in_app_purchase: "^1.0.0"
 
 
   flutter:

--- a/in_app_purchases/step_07/app/pubspec.lock
+++ b/in_app_purchases/step_07/app/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -260,7 +260,7 @@ packages:
       name: in_app_purchase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0"
+    version: "1.0.0"
   in_app_purchase_android:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -461,7 +461,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -496,21 +496,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.5"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.15"
+    version: "0.3.19"
   typed_data:
     dependency: transitive
     description:

--- a/in_app_purchases/step_07/app/pubspec.yaml
+++ b/in_app_purchases/step_07/app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   cloud_functions: "^1.0.3"
   cloud_firestore: "^1.0.4"
   google_sign_in: "^5.0.1"
-  in_app_purchase: "^0.6.0"
+  in_app_purchase: "^1.0.0"
 
 
   flutter:

--- a/in_app_purchases/step_08/app/pubspec.lock
+++ b/in_app_purchases/step_08/app/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -260,7 +260,7 @@ packages:
       name: in_app_purchase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0"
+    version: "1.0.0"
   in_app_purchase_android:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -461,7 +461,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -496,21 +496,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.5"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.15"
+    version: "0.3.19"
   typed_data:
     dependency: transitive
     description:

--- a/in_app_purchases/step_08/app/pubspec.yaml
+++ b/in_app_purchases/step_08/app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   cloud_functions: "^1.0.3"
   cloud_firestore: "^1.0.4"
   google_sign_in: "^5.0.1"
-  in_app_purchase: "^0.6.0"
+  in_app_purchase: "^1.0.0"
 
 
   flutter:

--- a/in_app_purchases/step_09/app/pubspec.lock
+++ b/in_app_purchases/step_09/app/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -260,7 +260,7 @@ packages:
       name: in_app_purchase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0"
+    version: "1.0.0"
   in_app_purchase_android:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -461,7 +461,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -496,21 +496,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.5"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.15"
+    version: "0.3.19"
   typed_data:
     dependency: transitive
     description:

--- a/in_app_purchases/step_09/app/pubspec.yaml
+++ b/in_app_purchases/step_09/app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   cloud_functions: "^1.0.3"
   cloud_firestore: "^1.0.4"
   google_sign_in: "^5.0.1"
-  in_app_purchase: "^0.6.0"
+  in_app_purchase: "^1.0.0"
 
 
   flutter:


### PR DESCRIPTION
The in_app_purchase plugin is updated to 1.0.0, the stable release.
https://pub.dev/packages/in_app_purchase