### PR TITLE
Startup Namer: Add semantic labels to icon buttons

### DIFF
--- a/startup_namer/step5_add_icons/lib/main.dart
+++ b/startup_namer/step5_add_icons/lib/main.dart
@@ -55,6 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
+        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer/step5_add_icons/lib/main.dart
+++ b/startup_namer/step5_add_icons/lib/main.dart
@@ -55,7 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
-        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
+        semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer/step6_add_interactivity/lib/main.dart
+++ b/startup_namer/step6_add_interactivity/lib/main.dart
@@ -55,6 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
+        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer/step6_add_interactivity/lib/main.dart
+++ b/startup_namer/step6_add_interactivity/lib/main.dart
@@ -55,7 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
-        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
+        semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer/step7_navigate_route/lib/main.dart
+++ b/startup_namer/step7_navigate_route/lib/main.dart
@@ -55,6 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
+        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer/step7_navigate_route/lib/main.dart
+++ b/startup_namer/step7_navigate_route/lib/main.dart
@@ -78,7 +78,7 @@ class _RandomWordsState extends State<RandomWords> {
         title: const Text('Startup Name Generator'),
         actions: [
           IconButton(
-            icon: Icon(Icons.list),
+            icon: const Icon(Icons.list),
             onPressed: _pushSaved,
             tooltip: 'Saved Suggestions',
           ),

--- a/startup_namer/step7_navigate_route/lib/main.dart
+++ b/startup_namer/step7_navigate_route/lib/main.dart
@@ -77,7 +77,11 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
         actions: [
-          IconButton(icon: const Icon(Icons.list), onPressed: _pushSaved),
+          IconButton(
+            icon: Icon(Icons.list),
+            onPressed: _pushSaved,
+            tooltip: 'Saved Suggestions',
+          ),
         ],
       ),
       body: _buildSuggestions(),

--- a/startup_namer/step7_navigate_route/lib/main.dart
+++ b/startup_namer/step7_navigate_route/lib/main.dart
@@ -55,7 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
-        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
+        semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer/step8_themes/lib/main.dart
+++ b/startup_namer/step8_themes/lib/main.dart
@@ -58,6 +58,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
+        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer/step8_themes/lib/main.dart
+++ b/startup_namer/step8_themes/lib/main.dart
@@ -81,7 +81,7 @@ class _RandomWordsState extends State<RandomWords> {
         title: const Text('Startup Name Generator'),
         actions: [
           IconButton(
-            icon: Icon(Icons.list),
+            icon: const Icon(Icons.list),
             onPressed: _pushSaved,
             tooltip: 'Saved Suggestions',
           ),

--- a/startup_namer/step8_themes/lib/main.dart
+++ b/startup_namer/step8_themes/lib/main.dart
@@ -58,7 +58,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
-        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
+        semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer/step8_themes/lib/main.dart
+++ b/startup_namer/step8_themes/lib/main.dart
@@ -80,7 +80,11 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
         actions: [
-          IconButton(icon: const Icon(Icons.list), onPressed: _pushSaved),
+          IconButton(
+            icon: Icon(Icons.list),
+            onPressed: _pushSaved,
+            tooltip: 'Saved Suggestions',
+          ),
         ],
       ),
       body: _buildSuggestions(),

--- a/startup_namer_null_safety/step5_add_icons/lib/main.dart
+++ b/startup_namer_null_safety/step5_add_icons/lib/main.dart
@@ -55,6 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
+        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer_null_safety/step5_add_icons/lib/main.dart
+++ b/startup_namer_null_safety/step5_add_icons/lib/main.dart
@@ -55,7 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
-        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
+        semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer_null_safety/step6_add_interactivity/lib/main.dart
+++ b/startup_namer_null_safety/step6_add_interactivity/lib/main.dart
@@ -55,6 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
+        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer_null_safety/step6_add_interactivity/lib/main.dart
+++ b/startup_namer_null_safety/step6_add_interactivity/lib/main.dart
@@ -55,7 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
-        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
+        semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer_null_safety/step7_navigate_route/lib/main.dart
+++ b/startup_namer_null_safety/step7_navigate_route/lib/main.dart
@@ -55,6 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
+        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer_null_safety/step7_navigate_route/lib/main.dart
+++ b/startup_namer_null_safety/step7_navigate_route/lib/main.dart
@@ -78,7 +78,7 @@ class _RandomWordsState extends State<RandomWords> {
         title: const Text('Startup Name Generator'),
         actions: [
           IconButton(
-            icon: Icon(Icons.list),
+            icon: const Icon(Icons.list),
             onPressed: _pushSaved,
             tooltip: 'Saved Suggestions',
           ),

--- a/startup_namer_null_safety/step7_navigate_route/lib/main.dart
+++ b/startup_namer_null_safety/step7_navigate_route/lib/main.dart
@@ -77,7 +77,11 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
         actions: [
-          IconButton(icon: const Icon(Icons.list), onPressed: _pushSaved),
+          IconButton(
+            icon: Icon(Icons.list),
+            onPressed: _pushSaved,
+            tooltip: 'Saved Suggestions',
+          ),
         ],
       ),
       body: _buildSuggestions(),

--- a/startup_namer_null_safety/step7_navigate_route/lib/main.dart
+++ b/startup_namer_null_safety/step7_navigate_route/lib/main.dart
@@ -55,7 +55,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
-        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
+        semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer_null_safety/step8_themes/lib/main.dart
+++ b/startup_namer_null_safety/step8_themes/lib/main.dart
@@ -58,6 +58,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
+        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer_null_safety/step8_themes/lib/main.dart
+++ b/startup_namer_null_safety/step8_themes/lib/main.dart
@@ -81,7 +81,7 @@ class _RandomWordsState extends State<RandomWords> {
         title: const Text('Startup Name Generator'),
         actions: [
           IconButton(
-            icon: Icon(Icons.list),
+            icon: const Icon(Icons.list),
             onPressed: _pushSaved,
             tooltip: 'Saved Suggestions',
           ),

--- a/startup_namer_null_safety/step8_themes/lib/main.dart
+++ b/startup_namer_null_safety/step8_themes/lib/main.dart
@@ -58,7 +58,7 @@ class _RandomWordsState extends State<RandomWords> {
       trailing: Icon(
         alreadySaved ? Icons.favorite : Icons.favorite_border,
         color: alreadySaved ? Colors.red : null,
-        semanticLabel: alreadySaved ? 'Saved' : 'Tap to save',
+        semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
       ),
       onTap: () {
         setState(() {

--- a/startup_namer_null_safety/step8_themes/lib/main.dart
+++ b/startup_namer_null_safety/step8_themes/lib/main.dart
@@ -80,7 +80,11 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
         actions: [
-          IconButton(icon: const Icon(Icons.list), onPressed: _pushSaved),
+          IconButton(
+            icon: Icon(Icons.list),
+            onPressed: _pushSaved,
+            tooltip: 'Saved Suggestions',
+          ),
         ],
       ),
       body: _buildSuggestions(),


### PR DESCRIPTION
This PR adds semantic labels to icon buttons throughout the Startup Namer app.

In its previous state, these buttons were not labelled for users of screen readers such as VoiceOver, making their purpose unclear.

The corresponding codelab ([first-flutter-app-pt2](https://codelabs.developers.google.com/codelabs/first-flutter-app-pt2)) should be updated to describe the purpose of these semantic labels, although I'm unable to do this as I believe the written text of codelabs is not on GitHub.