### PR TITLE
[cookbook]: Deprecated `accentColor` and `accentIconTheme`

### DIFF
--- a/cookbook/lib/app.dart
+++ b/cookbook/lib/app.dart
@@ -23,16 +23,16 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final themeData = ThemeData(
+      brightness: Brightness.light,
+      primaryColor: Colors.blue,
+    );
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Cookbook Examples',
-      theme: ThemeData(
-        brightness: Brightness.light,
-        colorScheme: ThemeData().colorScheme.copyWith(
-              primary: Colors.blue,
-              secondary: Colors.indigo,
-            ),
-      ),
+      theme: themeData.copyWith(
+          colorScheme:
+              themeData.colorScheme.copyWith(secondary: Colors.indigo)),
       home: home ?? const Home(),
     );
   }

--- a/cookbook/lib/app.dart
+++ b/cookbook/lib/app.dart
@@ -28,8 +28,10 @@ class App extends StatelessWidget {
       title: 'Cookbook Examples',
       theme: ThemeData(
         brightness: Brightness.light,
-        primaryColor: Colors.blue,
-        accentColor: Colors.indigo,
+        colorScheme: ThemeData().colorScheme.copyWith(
+              primary: Colors.blue,
+              secondary: Colors.indigo,
+            ),
       ),
       home: home ?? const Home(),
     );

--- a/cookbook/lib/examples/expandable_fab.dart
+++ b/cookbook/lib/examples/expandable_fab.dart
@@ -268,10 +268,10 @@ class ActionButton extends StatelessWidget {
     return Material(
       shape: const CircleBorder(),
       clipBehavior: Clip.antiAlias,
-      color: theme.accentColor,
+      color: theme.colorScheme.secondary,
       elevation: 4.0,
       child: IconTheme.merge(
-        data: theme.accentIconTheme,
+        data: IconThemeData(color: theme.colorScheme.secondary),
         child: IconButton(
           onPressed: onPressed,
           icon: icon,

--- a/flutter_ci_script_dev.sh
+++ b/flutter_ci_script_dev.sh
@@ -7,9 +7,7 @@ source "$DIR/flutter_ci_script_shared.sh"
 
 declare -a CODELABS=(
   "add_flutter_to_android_app"
-  # TODO(domesticmouse) re-enable once cookbook is updated for deprecated member usage.
-  # Tracking bug: https://github.com/flutter/flutter/issues/84665
-  # "cookbook"
+  "cookbook"
   "cupertino_store"
   "firebase-get-to-know-flutter"
   # TODO(domesticmouse) re-enable once friendly_chat is updated for deprecated member usage.


### PR DESCRIPTION
Hey @matthew-carroll, I'm curious if you have input on dealing with the deprecation of `accentColor` and `accentIconTheme` in the cookbook.

Context for this fix: https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide

fixes: https://github.com/flutter/flutter/issues/84665