### PR TITLE
[friendly_chat]: deprecated `accentColor`

### DIFF
--- a/flutter_ci_script_dev.sh
+++ b/flutter_ci_script_dev.sh
@@ -12,9 +12,7 @@ declare -a CODELABS=(
   # "cookbook"
   "cupertino_store"
   "firebase-get-to-know-flutter"
-  # TODO(domesticmouse) re-enable once friendly_chat is updated for deprecated member usage.
-  # Tracking bug: https://github.com/flutter/flutter/issues/84668
-  # "friendly_chat"
+  "friendly_chat"
   # `github-graphql-client` is formatting differently on stable vs dev. 
   # "github-graphql-client"
   "google-maps-in-flutter"

--- a/friendly_chat/step_05/lib/main.dart
+++ b/friendly_chat/step_05/lib/main.dart
@@ -44,7 +44,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   Widget _buildTextComposer() {
     return IconTheme(
-      data: IconThemeData(color: Theme.of(context).accentColor),
+      data: IconThemeData(color: Theme.of(context).colorScheme.secondary),
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 8.0),
         child: Row(

--- a/friendly_chat/step_07/lib/main.dart
+++ b/friendly_chat/step_07/lib/main.dart
@@ -93,7 +93,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   Widget _buildTextComposer() {
     return IconTheme(
-      data: IconThemeData(color: Theme.of(context).accentColor),
+      data: IconThemeData(color: Theme.of(context).colorScheme.secondary),
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 8.0),
         child: Row(

--- a/friendly_chat/step_08/lib/main.dart
+++ b/friendly_chat/step_08/lib/main.dart
@@ -99,7 +99,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
 
   Widget _buildTextComposer() {
     return IconTheme(
-      data: IconThemeData(color: Theme.of(context).accentColor),
+      data: IconThemeData(color: Theme.of(context).colorScheme.secondary),
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 8.0),
         child: Row(

--- a/friendly_chat/step_09/lib/main.dart
+++ b/friendly_chat/step_09/lib/main.dart
@@ -19,8 +19,8 @@ final ThemeData kIOSTheme = ThemeData(
 );
 
 final ThemeData kDefaultTheme = ThemeData(
-  primarySwatch: Colors.purple,
-  accentColor: Colors.orangeAccent[400],
+  colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.purple)
+      .copyWith(secondary: Colors.orangeAccent[400]),
 );
 
 String _name = 'Your Name';
@@ -128,7 +128,7 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
 
   Widget _buildTextComposer() {
     return IconTheme(
-      data: IconThemeData(color: Theme.of(context).accentColor),
+      data: IconThemeData(color: Theme.of(context).colorScheme.secondary),
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 8.0),
         child: Row(


### PR DESCRIPTION
Dealing with deprecated `accentColor`

Context for this fix: https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide

fixes: https://github.com/flutter/flutter/issues/84668