### PR TITLE
Pin `subosito/flutter-action`

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: "12.x"
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8
         with:
           channel: ${{ matrix.flutter_version }}
       - run: dart --version


### PR DESCRIPTION
Adds hardcoded commits for the GitHub actions we're using for CI/CD.

See this issue for the (security-related) rationale: flutter/flutter#87504