### PR TITLE
Add no-response workflow to codelabs.

### DIFF
--- a/.github/workflows/no-response.yaml
+++ b/.github/workflows/no-response.yaml
@@ -1,0 +1,33 @@
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  issues: write
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb
+        with:
+          token: ${{ github.token }}
+          # Comment to post when closing an Issue for lack of response. Set to `false` to disable
+          closeComment: >
+            Without additional information we're not able to resolve this issue,
+            so it will be closed at this time. You're still free to add more info
+            and respond to any questions above, though. We'll reopen the case
+            if you do. Thanks for your contribution!
+          # Number of days of inactivity before an issue is closed for lack of response.
+          daysUntilClose: 21
+          # Label requiring a response.
+          responseRequiredLabel: "waiting for customer response"


### PR DESCRIPTION
This is part of enabling the no-response workflow in the different
flutter repositories with issues enabled.

Bug: https://github.com/flutter/flutter/issues/87503