### PR TITLE
[photos-sharing] Fix share recipient unable to add photos to album.

### DIFF
--- a/photos-sharing/final/build.yaml
+++ b/photos-sharing/final/build.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          include_if_null: false

--- a/photos-sharing/final/lib/model/photos_library_api_model.dart
+++ b/photos-sharing/final/lib/model/photos_library_api_model.dart
@@ -95,8 +95,11 @@ class PhotosLibraryApiModel extends Model {
   }
 
   Future<ShareAlbumResponse> shareAlbum(String id) async {
-    final response =
-        await client!.shareAlbum(ShareAlbumRequest.defaultOptions(id));
+    // Share the album with collaboration and commenting enabled.
+    SharedAlbumOptions options = SharedAlbumOptions(true, true);
+
+    final response = await client!.shareAlbum(ShareAlbumRequest(id, options));
+
     updateAlbums();
     return response;
   }

--- a/photos-sharing/final/lib/model/photos_library_api_model.dart
+++ b/photos-sharing/final/lib/model/photos_library_api_model.dart
@@ -94,11 +94,9 @@ class PhotosLibraryApiModel extends Model {
     return response;
   }
 
-  Future<ShareAlbumResponse> shareAlbum(String id) async {
-    // Share the album with collaboration and commenting enabled.
-    SharedAlbumOptions options = SharedAlbumOptions(true, true);
-
-    final response = await client!.shareAlbum(ShareAlbumRequest(id, options));
+  Future<ShareAlbumResponse> shareAlbum(String albumId) async {
+    final response = await client!.shareAlbum(
+        ShareAlbumRequest(albumId, SharedAlbumOptions.fullCollaboration()));
 
     updateAlbums();
     return response;

--- a/photos-sharing/final/lib/photos_library_api/album.dart
+++ b/photos-sharing/final/lib/photos_library_api/album.dart
@@ -67,6 +67,9 @@ class ShareInfo {
 class SharedAlbumOptions {
   SharedAlbumOptions(this.isCollaborative, this.isCommentable);
 
+  // Full collaboration enables the addition of media and commenting.
+  SharedAlbumOptions.fullCollaboration() : this(true, true);
+
   factory SharedAlbumOptions.fromJson(Map<String, dynamic> json) =>
       _$SharedAlbumOptionsFromJson(json);
 

--- a/photos-sharing/final/lib/photos_library_api/album.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/album.g.dart
@@ -37,16 +37,25 @@ Album _$AlbumFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$AlbumToJson(Album instance) => <String, dynamic>{
-      'id': instance.id,
-      'title': instance.title,
-      'productUrl': instance.productUrl,
-      'isWriteable': instance.isWriteable,
-      'shareInfo': instance.shareInfo,
-      'mediaItemsCount': instance.mediaItemsCount,
-      'coverPhotoBaseUrl': instance.coverPhotoBaseUrl,
-      'coverPhotoMediaItemId': instance.coverPhotoMediaItemId,
-    };
+Map<String, dynamic> _$AlbumToJson(Album instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('id', instance.id);
+  writeNotNull('title', instance.title);
+  writeNotNull('productUrl', instance.productUrl);
+  writeNotNull('isWriteable', instance.isWriteable);
+  writeNotNull('shareInfo', instance.shareInfo);
+  writeNotNull('mediaItemsCount', instance.mediaItemsCount);
+  writeNotNull('coverPhotoBaseUrl', instance.coverPhotoBaseUrl);
+  writeNotNull('coverPhotoMediaItemId', instance.coverPhotoMediaItemId);
+  return val;
+}
 
 ShareInfo _$ShareInfoFromJson(Map<String, dynamic> json) {
   return ShareInfo(
@@ -60,12 +69,21 @@ ShareInfo _$ShareInfoFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$ShareInfoToJson(ShareInfo instance) => <String, dynamic>{
-      'sharedAlbumOptions': instance.sharedAlbumOptions,
-      'shareableUrl': instance.shareableUrl,
-      'shareToken': instance.shareToken,
-      'isJoined': instance.isJoined,
-    };
+Map<String, dynamic> _$ShareInfoToJson(ShareInfo instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('sharedAlbumOptions', instance.sharedAlbumOptions);
+  writeNotNull('shareableUrl', instance.shareableUrl);
+  writeNotNull('shareToken', instance.shareToken);
+  writeNotNull('isJoined', instance.isJoined);
+  return val;
+}
 
 SharedAlbumOptions _$SharedAlbumOptionsFromJson(Map<String, dynamic> json) {
   return SharedAlbumOptions(
@@ -74,8 +92,16 @@ SharedAlbumOptions _$SharedAlbumOptionsFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$SharedAlbumOptionsToJson(SharedAlbumOptions instance) =>
-    <String, dynamic>{
-      'isCollaborative': instance.isCollaborative,
-      'isCommentable': instance.isCommentable,
-    };
+Map<String, dynamic> _$SharedAlbumOptionsToJson(SharedAlbumOptions instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('isCollaborative', instance.isCollaborative);
+  writeNotNull('isCommentable', instance.isCommentable);
+  return val;
+}

--- a/photos-sharing/final/lib/photos_library_api/batch_create_media_items_request.dart
+++ b/photos-sharing/final/lib/photos_library_api/batch_create_media_items_request.dart
@@ -20,15 +20,13 @@ part 'batch_create_media_items_request.g.dart';
 
 @JsonSerializable()
 class BatchCreateMediaItemsRequest {
-  BatchCreateMediaItemsRequest(
-      this.albumId, this.newMediaItems, this.albumPosition);
+  BatchCreateMediaItemsRequest(this.albumId, this.newMediaItems,
+      [this.albumPosition]);
 
   static BatchCreateMediaItemsRequest inAlbum(
       String uploadToken, String? albumId, String? description) {
     return BatchCreateMediaItemsRequest(
-        albumId,
-        <NewMediaItem>[NewMediaItem.simple(uploadToken, description)],
-        AlbumPosition.lastInAlbum());
+        albumId, <NewMediaItem>[NewMediaItem.simple(uploadToken, description)]);
   }
 
   factory BatchCreateMediaItemsRequest.fromJson(Map<String, dynamic> json) =>

--- a/photos-sharing/final/lib/photos_library_api/batch_create_media_items_request.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/batch_create_media_items_request.g.dart
@@ -36,12 +36,20 @@ BatchCreateMediaItemsRequest _$BatchCreateMediaItemsRequestFromJson(
 }
 
 Map<String, dynamic> _$BatchCreateMediaItemsRequestToJson(
-        BatchCreateMediaItemsRequest instance) =>
-    <String, dynamic>{
-      'albumId': instance.albumId,
-      'newMediaItems': instance.newMediaItems,
-      'albumPosition': instance.albumPosition,
-    };
+    BatchCreateMediaItemsRequest instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('albumId', instance.albumId);
+  val['newMediaItems'] = instance.newMediaItems;
+  writeNotNull('albumPosition', instance.albumPosition);
+  return val;
+}
 
 NewMediaItem _$NewMediaItemFromJson(Map<String, dynamic> json) {
   return NewMediaItem(
@@ -53,11 +61,19 @@ NewMediaItem _$NewMediaItemFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$NewMediaItemToJson(NewMediaItem instance) =>
-    <String, dynamic>{
-      'description': instance.description,
-      'simpleMediaItem': instance.simpleMediaItem,
-    };
+Map<String, dynamic> _$NewMediaItemToJson(NewMediaItem instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('description', instance.description);
+  writeNotNull('simpleMediaItem', instance.simpleMediaItem);
+  return val;
+}
 
 SimpleMediaItem _$SimpleMediaItemFromJson(Map<String, dynamic> json) {
   return SimpleMediaItem(
@@ -78,12 +94,20 @@ AlbumPosition _$AlbumPositionFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$AlbumPositionToJson(AlbumPosition instance) =>
-    <String, dynamic>{
-      'relativeMediaItemId': instance.relativeMediaItemId,
-      'relativeEnrichmentItemId': instance.relativeEnrichmentItemId,
-      'position': _$PositionTypeEnumMap[instance.position],
-    };
+Map<String, dynamic> _$AlbumPositionToJson(AlbumPosition instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('relativeMediaItemId', instance.relativeMediaItemId);
+  writeNotNull('relativeEnrichmentItemId', instance.relativeEnrichmentItemId);
+  val['position'] = _$PositionTypeEnumMap[instance.position];
+  return val;
+}
 
 K _$enumDecode<K, V>(
   Map<K, V> enumValues,

--- a/photos-sharing/final/lib/photos_library_api/batch_create_media_items_response.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/batch_create_media_items_response.g.dart
@@ -32,10 +32,18 @@ BatchCreateMediaItemsResponse _$BatchCreateMediaItemsResponseFromJson(
 }
 
 Map<String, dynamic> _$BatchCreateMediaItemsResponseToJson(
-        BatchCreateMediaItemsResponse instance) =>
-    <String, dynamic>{
-      'newMediaItemResults': instance.newMediaItemResults,
-    };
+    BatchCreateMediaItemsResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('newMediaItemResults', instance.newMediaItemResults);
+  return val;
+}
 
 NewMediaItemResult _$NewMediaItemResultFromJson(Map<String, dynamic> json) {
   return NewMediaItemResult(
@@ -46,8 +54,17 @@ NewMediaItemResult _$NewMediaItemResultFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$NewMediaItemResultToJson(NewMediaItemResult instance) =>
-    <String, dynamic>{
-      'uploadToken': instance.uploadToken,
-      'mediaItem': instance.mediaItem,
-    };
+Map<String, dynamic> _$NewMediaItemResultToJson(NewMediaItemResult instance) {
+  final val = <String, dynamic>{
+    'uploadToken': instance.uploadToken,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('mediaItem', instance.mediaItem);
+  return val;
+}

--- a/photos-sharing/final/lib/photos_library_api/join_shared_album_response.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/join_shared_album_response.g.dart
@@ -32,7 +32,15 @@ JoinSharedAlbumResponse _$JoinSharedAlbumResponseFromJson(
 }
 
 Map<String, dynamic> _$JoinSharedAlbumResponseToJson(
-        JoinSharedAlbumResponse instance) =>
-    <String, dynamic>{
-      'album': instance.album,
-    };
+    JoinSharedAlbumResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('album', instance.album);
+  return val;
+}

--- a/photos-sharing/final/lib/photos_library_api/list_albums_response.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/list_albums_response.g.dart
@@ -31,8 +31,16 @@ ListAlbumsResponse _$ListAlbumsResponseFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$ListAlbumsResponseToJson(ListAlbumsResponse instance) =>
-    <String, dynamic>{
-      'albums': instance.albums,
-      'nextPageToken': instance.nextPageToken,
-    };
+Map<String, dynamic> _$ListAlbumsResponseToJson(ListAlbumsResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('albums', instance.albums);
+  writeNotNull('nextPageToken', instance.nextPageToken);
+  return val;
+}

--- a/photos-sharing/final/lib/photos_library_api/list_shared_albums_response.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/list_shared_albums_response.g.dart
@@ -33,8 +33,16 @@ ListSharedAlbumsResponse _$ListSharedAlbumsResponseFromJson(
 }
 
 Map<String, dynamic> _$ListSharedAlbumsResponseToJson(
-        ListSharedAlbumsResponse instance) =>
-    <String, dynamic>{
-      'sharedAlbums': instance.sharedAlbums,
-      'nextPageToken': instance.nextPageToken,
-    };
+    ListSharedAlbumsResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('sharedAlbums', instance.sharedAlbums);
+  writeNotNull('nextPageToken', instance.nextPageToken);
+  return val;
+}

--- a/photos-sharing/final/lib/photos_library_api/photos_library_api_client.dart
+++ b/photos-sharing/final/lib/photos_library_api/photos_library_api_client.dart
@@ -67,7 +67,8 @@ class PhotosLibraryApiClient {
     final response = await http.post(
         Uri.parse(
             'https://photoslibrary.googleapis.com/v1/albums/${request.albumId}:share'),
-        headers: await _authHeaders);
+        headers: await _authHeaders,
+        body: jsonEncode(request));
 
     printError(response);
 

--- a/photos-sharing/final/lib/photos_library_api/search_media_items_request.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/search_media_items_request.g.dart
@@ -32,9 +32,17 @@ SearchMediaItemsRequest _$SearchMediaItemsRequestFromJson(
 }
 
 Map<String, dynamic> _$SearchMediaItemsRequestToJson(
-        SearchMediaItemsRequest instance) =>
-    <String, dynamic>{
-      'albumId': instance.albumId,
-      'pageSize': instance.pageSize,
-      'pageToken': instance.pageToken,
-    };
+    SearchMediaItemsRequest instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('albumId', instance.albumId);
+  writeNotNull('pageSize', instance.pageSize);
+  writeNotNull('pageToken', instance.pageToken);
+  return val;
+}

--- a/photos-sharing/final/lib/photos_library_api/search_media_items_response.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/search_media_items_response.g.dart
@@ -33,8 +33,16 @@ SearchMediaItemsResponse _$SearchMediaItemsResponseFromJson(
 }
 
 Map<String, dynamic> _$SearchMediaItemsResponseToJson(
-        SearchMediaItemsResponse instance) =>
-    <String, dynamic>{
-      'mediaItems': instance.mediaItems,
-      'nextPageToken': instance.nextPageToken,
-    };
+    SearchMediaItemsResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('mediaItems', instance.mediaItems);
+  writeNotNull('nextPageToken', instance.nextPageToken);
+  return val;
+}

--- a/photos-sharing/final/lib/photos_library_api/share_album_request.dart
+++ b/photos-sharing/final/lib/photos_library_api/share_album_request.dart
@@ -14,8 +14,22 @@
  * limitations under the License.
  */
 
-class ShareAlbumRequest {
-  ShareAlbumRequest.defaultOptions(this.albumId);
+import 'package:json_annotation/json_annotation.dart';
 
+import 'album.dart';
+
+part 'share_album_request.g.dart';
+
+@JsonSerializable(createFactory: false)
+class ShareAlbumRequest {
+  ShareAlbumRequest(this.albumId, [this.sharedAlbumOptions]);
+
+  Map<String, dynamic> toJson() => _$ShareAlbumRequestToJson(this);
+
+  // Album ID is not included in the JSON encoding of this request.
+  // It must be supplied separately to the call.
+  @JsonKey(ignore: true)
   String albumId;
+
+  SharedAlbumOptions? sharedAlbumOptions;
 }

--- a/photos-sharing/final/lib/photos_library_api/share_album_request.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/share_album_request.g.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,14 @@
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'media_item.dart';
+part of 'share_album_request.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-MediaItem _$MediaItemFromJson(Map<String, dynamic> json) {
-  return MediaItem(
-    json['id'] as String,
-    json['description'] as String?,
-    json['productUrl'] as String?,
-    json['baseUrl'] as String?,
-  );
-}
-
-Map<String, dynamic> _$MediaItemToJson(MediaItem instance) {
-  final val = <String, dynamic>{
-    'id': instance.id,
-  };
+Map<String, dynamic> _$ShareAlbumRequestToJson(ShareAlbumRequest instance) {
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -42,8 +31,6 @@ Map<String, dynamic> _$MediaItemToJson(MediaItem instance) {
     }
   }
 
-  writeNotNull('description', instance.description);
-  writeNotNull('productUrl', instance.productUrl);
-  writeNotNull('baseUrl', instance.baseUrl);
+  writeNotNull('sharedAlbumOptions', instance.sharedAlbumOptions);
   return val;
 }

--- a/photos-sharing/final/lib/photos_library_api/share_album_response.g.dart
+++ b/photos-sharing/final/lib/photos_library_api/share_album_response.g.dart
@@ -30,7 +30,15 @@ ShareAlbumResponse _$ShareAlbumResponseFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$ShareAlbumResponseToJson(ShareAlbumResponse instance) =>
-    <String, dynamic>{
-      'shareInfo': instance.shareInfo,
-    };
+Map<String, dynamic> _$ShareAlbumResponseToJson(ShareAlbumResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('shareInfo', instance.shareInfo);
+  return val;
+}

--- a/photos-sharing/initial/build.yaml
+++ b/photos-sharing/initial/build.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          include_if_null: false

--- a/photos-sharing/initial/lib/model/photos_library_api_model.dart
+++ b/photos-sharing/initial/lib/model/photos_library_api_model.dart
@@ -92,8 +92,11 @@ class PhotosLibraryApiModel extends Model {
   }
 
   Future<ShareAlbumResponse> shareAlbum(String id) async {
-    final response =
-        await client!.shareAlbum(ShareAlbumRequest.defaultOptions(id));
+    // Share the album with collaboration and commenting enabled.
+    SharedAlbumOptions options = SharedAlbumOptions(true, true);
+
+    final response = await client!.shareAlbum(ShareAlbumRequest(id, options));
+
     updateAlbums();
     return response;
   }

--- a/photos-sharing/initial/lib/model/photos_library_api_model.dart
+++ b/photos-sharing/initial/lib/model/photos_library_api_model.dart
@@ -91,11 +91,9 @@ class PhotosLibraryApiModel extends Model {
     return response;
   }
 
-  Future<ShareAlbumResponse> shareAlbum(String id) async {
-    // Share the album with collaboration and commenting enabled.
-    SharedAlbumOptions options = SharedAlbumOptions(true, true);
-
-    final response = await client!.shareAlbum(ShareAlbumRequest(id, options));
+  Future<ShareAlbumResponse> shareAlbum(String albumId) async {
+    final response = await client!.shareAlbum(
+        ShareAlbumRequest(albumId, SharedAlbumOptions.fullCollaboration()));
 
     updateAlbums();
     return response;

--- a/photos-sharing/initial/lib/photos_library_api/album.dart
+++ b/photos-sharing/initial/lib/photos_library_api/album.dart
@@ -67,6 +67,9 @@ class ShareInfo {
 class SharedAlbumOptions {
   SharedAlbumOptions(this.isCollaborative, this.isCommentable);
 
+  // Full collaboration enables the addition of media and commenting.
+  SharedAlbumOptions.fullCollaboration() : this(true, true);
+
   factory SharedAlbumOptions.fromJson(Map<String, dynamic> json) =>
       _$SharedAlbumOptionsFromJson(json);
 

--- a/photos-sharing/initial/lib/photos_library_api/album.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/album.g.dart
@@ -37,16 +37,25 @@ Album _$AlbumFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$AlbumToJson(Album instance) => <String, dynamic>{
-      'id': instance.id,
-      'title': instance.title,
-      'productUrl': instance.productUrl,
-      'isWriteable': instance.isWriteable,
-      'shareInfo': instance.shareInfo,
-      'mediaItemsCount': instance.mediaItemsCount,
-      'coverPhotoBaseUrl': instance.coverPhotoBaseUrl,
-      'coverPhotoMediaItemId': instance.coverPhotoMediaItemId,
-    };
+Map<String, dynamic> _$AlbumToJson(Album instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('id', instance.id);
+  writeNotNull('title', instance.title);
+  writeNotNull('productUrl', instance.productUrl);
+  writeNotNull('isWriteable', instance.isWriteable);
+  writeNotNull('shareInfo', instance.shareInfo);
+  writeNotNull('mediaItemsCount', instance.mediaItemsCount);
+  writeNotNull('coverPhotoBaseUrl', instance.coverPhotoBaseUrl);
+  writeNotNull('coverPhotoMediaItemId', instance.coverPhotoMediaItemId);
+  return val;
+}
 
 ShareInfo _$ShareInfoFromJson(Map<String, dynamic> json) {
   return ShareInfo(
@@ -60,12 +69,21 @@ ShareInfo _$ShareInfoFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$ShareInfoToJson(ShareInfo instance) => <String, dynamic>{
-      'sharedAlbumOptions': instance.sharedAlbumOptions,
-      'shareableUrl': instance.shareableUrl,
-      'shareToken': instance.shareToken,
-      'isJoined': instance.isJoined,
-    };
+Map<String, dynamic> _$ShareInfoToJson(ShareInfo instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('sharedAlbumOptions', instance.sharedAlbumOptions);
+  writeNotNull('shareableUrl', instance.shareableUrl);
+  writeNotNull('shareToken', instance.shareToken);
+  writeNotNull('isJoined', instance.isJoined);
+  return val;
+}
 
 SharedAlbumOptions _$SharedAlbumOptionsFromJson(Map<String, dynamic> json) {
   return SharedAlbumOptions(
@@ -74,8 +92,16 @@ SharedAlbumOptions _$SharedAlbumOptionsFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$SharedAlbumOptionsToJson(SharedAlbumOptions instance) =>
-    <String, dynamic>{
-      'isCollaborative': instance.isCollaborative,
-      'isCommentable': instance.isCommentable,
-    };
+Map<String, dynamic> _$SharedAlbumOptionsToJson(SharedAlbumOptions instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('isCollaborative', instance.isCollaborative);
+  writeNotNull('isCommentable', instance.isCommentable);
+  return val;
+}

--- a/photos-sharing/initial/lib/photos_library_api/batch_create_media_items_request.dart
+++ b/photos-sharing/initial/lib/photos_library_api/batch_create_media_items_request.dart
@@ -20,15 +20,13 @@ part 'batch_create_media_items_request.g.dart';
 
 @JsonSerializable()
 class BatchCreateMediaItemsRequest {
-  BatchCreateMediaItemsRequest(
-      this.albumId, this.newMediaItems, this.albumPosition);
+  BatchCreateMediaItemsRequest(this.albumId, this.newMediaItems,
+      [this.albumPosition]);
 
   static BatchCreateMediaItemsRequest inAlbum(
       String uploadToken, String? albumId, String? description) {
     return BatchCreateMediaItemsRequest(
-        albumId,
-        <NewMediaItem>[NewMediaItem.simple(uploadToken, description)],
-        AlbumPosition.lastInAlbum());
+        albumId, <NewMediaItem>[NewMediaItem.simple(uploadToken, description)]);
   }
 
   factory BatchCreateMediaItemsRequest.fromJson(Map<String, dynamic> json) =>

--- a/photos-sharing/initial/lib/photos_library_api/batch_create_media_items_request.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/batch_create_media_items_request.g.dart
@@ -36,12 +36,20 @@ BatchCreateMediaItemsRequest _$BatchCreateMediaItemsRequestFromJson(
 }
 
 Map<String, dynamic> _$BatchCreateMediaItemsRequestToJson(
-        BatchCreateMediaItemsRequest instance) =>
-    <String, dynamic>{
-      'albumId': instance.albumId,
-      'newMediaItems': instance.newMediaItems,
-      'albumPosition': instance.albumPosition,
-    };
+    BatchCreateMediaItemsRequest instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('albumId', instance.albumId);
+  val['newMediaItems'] = instance.newMediaItems;
+  writeNotNull('albumPosition', instance.albumPosition);
+  return val;
+}
 
 NewMediaItem _$NewMediaItemFromJson(Map<String, dynamic> json) {
   return NewMediaItem(
@@ -53,11 +61,19 @@ NewMediaItem _$NewMediaItemFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$NewMediaItemToJson(NewMediaItem instance) =>
-    <String, dynamic>{
-      'description': instance.description,
-      'simpleMediaItem': instance.simpleMediaItem,
-    };
+Map<String, dynamic> _$NewMediaItemToJson(NewMediaItem instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('description', instance.description);
+  writeNotNull('simpleMediaItem', instance.simpleMediaItem);
+  return val;
+}
 
 SimpleMediaItem _$SimpleMediaItemFromJson(Map<String, dynamic> json) {
   return SimpleMediaItem(
@@ -78,12 +94,20 @@ AlbumPosition _$AlbumPositionFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$AlbumPositionToJson(AlbumPosition instance) =>
-    <String, dynamic>{
-      'relativeMediaItemId': instance.relativeMediaItemId,
-      'relativeEnrichmentItemId': instance.relativeEnrichmentItemId,
-      'position': _$PositionTypeEnumMap[instance.position],
-    };
+Map<String, dynamic> _$AlbumPositionToJson(AlbumPosition instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('relativeMediaItemId', instance.relativeMediaItemId);
+  writeNotNull('relativeEnrichmentItemId', instance.relativeEnrichmentItemId);
+  val['position'] = _$PositionTypeEnumMap[instance.position];
+  return val;
+}
 
 K _$enumDecode<K, V>(
   Map<K, V> enumValues,

--- a/photos-sharing/initial/lib/photos_library_api/batch_create_media_items_response.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/batch_create_media_items_response.g.dart
@@ -32,10 +32,18 @@ BatchCreateMediaItemsResponse _$BatchCreateMediaItemsResponseFromJson(
 }
 
 Map<String, dynamic> _$BatchCreateMediaItemsResponseToJson(
-        BatchCreateMediaItemsResponse instance) =>
-    <String, dynamic>{
-      'newMediaItemResults': instance.newMediaItemResults,
-    };
+    BatchCreateMediaItemsResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('newMediaItemResults', instance.newMediaItemResults);
+  return val;
+}
 
 NewMediaItemResult _$NewMediaItemResultFromJson(Map<String, dynamic> json) {
   return NewMediaItemResult(
@@ -46,8 +54,17 @@ NewMediaItemResult _$NewMediaItemResultFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$NewMediaItemResultToJson(NewMediaItemResult instance) =>
-    <String, dynamic>{
-      'uploadToken': instance.uploadToken,
-      'mediaItem': instance.mediaItem,
-    };
+Map<String, dynamic> _$NewMediaItemResultToJson(NewMediaItemResult instance) {
+  final val = <String, dynamic>{
+    'uploadToken': instance.uploadToken,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('mediaItem', instance.mediaItem);
+  return val;
+}

--- a/photos-sharing/initial/lib/photos_library_api/join_shared_album_response.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/join_shared_album_response.g.dart
@@ -32,7 +32,15 @@ JoinSharedAlbumResponse _$JoinSharedAlbumResponseFromJson(
 }
 
 Map<String, dynamic> _$JoinSharedAlbumResponseToJson(
-        JoinSharedAlbumResponse instance) =>
-    <String, dynamic>{
-      'album': instance.album,
-    };
+    JoinSharedAlbumResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('album', instance.album);
+  return val;
+}

--- a/photos-sharing/initial/lib/photos_library_api/list_albums_response.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/list_albums_response.g.dart
@@ -31,8 +31,16 @@ ListAlbumsResponse _$ListAlbumsResponseFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$ListAlbumsResponseToJson(ListAlbumsResponse instance) =>
-    <String, dynamic>{
-      'albums': instance.albums,
-      'nextPageToken': instance.nextPageToken,
-    };
+Map<String, dynamic> _$ListAlbumsResponseToJson(ListAlbumsResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('albums', instance.albums);
+  writeNotNull('nextPageToken', instance.nextPageToken);
+  return val;
+}

--- a/photos-sharing/initial/lib/photos_library_api/list_shared_albums_response.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/list_shared_albums_response.g.dart
@@ -33,8 +33,16 @@ ListSharedAlbumsResponse _$ListSharedAlbumsResponseFromJson(
 }
 
 Map<String, dynamic> _$ListSharedAlbumsResponseToJson(
-        ListSharedAlbumsResponse instance) =>
-    <String, dynamic>{
-      'sharedAlbums': instance.sharedAlbums,
-      'nextPageToken': instance.nextPageToken,
-    };
+    ListSharedAlbumsResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('sharedAlbums', instance.sharedAlbums);
+  writeNotNull('nextPageToken', instance.nextPageToken);
+  return val;
+}

--- a/photos-sharing/initial/lib/photos_library_api/media_item.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/media_item.g.dart
@@ -31,9 +31,19 @@ MediaItem _$MediaItemFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$MediaItemToJson(MediaItem instance) => <String, dynamic>{
-      'id': instance.id,
-      'description': instance.description,
-      'productUrl': instance.productUrl,
-      'baseUrl': instance.baseUrl,
-    };
+Map<String, dynamic> _$MediaItemToJson(MediaItem instance) {
+  final val = <String, dynamic>{
+    'id': instance.id,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('description', instance.description);
+  writeNotNull('productUrl', instance.productUrl);
+  writeNotNull('baseUrl', instance.baseUrl);
+  return val;
+}

--- a/photos-sharing/initial/lib/photos_library_api/photos_library_api_client.dart
+++ b/photos-sharing/initial/lib/photos_library_api/photos_library_api_client.dart
@@ -67,7 +67,8 @@ class PhotosLibraryApiClient {
     final response = await http.post(
         Uri.parse(
             'https://photoslibrary.googleapis.com/v1/albums/${request.albumId}:share'),
-        headers: await _authHeaders);
+        headers: await _authHeaders,
+        body: jsonEncode(request));
 
     printError(response);
 

--- a/photos-sharing/initial/lib/photos_library_api/search_media_items_request.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/search_media_items_request.g.dart
@@ -32,9 +32,17 @@ SearchMediaItemsRequest _$SearchMediaItemsRequestFromJson(
 }
 
 Map<String, dynamic> _$SearchMediaItemsRequestToJson(
-        SearchMediaItemsRequest instance) =>
-    <String, dynamic>{
-      'albumId': instance.albumId,
-      'pageSize': instance.pageSize,
-      'pageToken': instance.pageToken,
-    };
+    SearchMediaItemsRequest instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('albumId', instance.albumId);
+  writeNotNull('pageSize', instance.pageSize);
+  writeNotNull('pageToken', instance.pageToken);
+  return val;
+}

--- a/photos-sharing/initial/lib/photos_library_api/search_media_items_response.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/search_media_items_response.g.dart
@@ -33,8 +33,16 @@ SearchMediaItemsResponse _$SearchMediaItemsResponseFromJson(
 }
 
 Map<String, dynamic> _$SearchMediaItemsResponseToJson(
-        SearchMediaItemsResponse instance) =>
-    <String, dynamic>{
-      'mediaItems': instance.mediaItems,
-      'nextPageToken': instance.nextPageToken,
-    };
+    SearchMediaItemsResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('mediaItems', instance.mediaItems);
+  writeNotNull('nextPageToken', instance.nextPageToken);
+  return val;
+}

--- a/photos-sharing/initial/lib/photos_library_api/share_album_request.dart
+++ b/photos-sharing/initial/lib/photos_library_api/share_album_request.dart
@@ -14,8 +14,22 @@
  * limitations under the License.
  */
 
-class ShareAlbumRequest {
-  ShareAlbumRequest.defaultOptions(this.albumId);
+import 'package:json_annotation/json_annotation.dart';
 
+import 'album.dart';
+
+part 'share_album_request.g.dart';
+
+@JsonSerializable(createFactory: false)
+class ShareAlbumRequest {
+  ShareAlbumRequest(this.albumId, [this.sharedAlbumOptions]);
+
+  Map<String, dynamic> toJson() => _$ShareAlbumRequestToJson(this);
+
+  // Album ID is not included in the JSON encoding of this request.
+  // It must be supplied separately to the call.
+  @JsonKey(ignore: true)
   String albumId;
+
+  SharedAlbumOptions? sharedAlbumOptions;
 }

--- a/photos-sharing/initial/lib/photos_library_api/share_album_request.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/share_album_request.g.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,14 @@
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'media_item.dart';
+part of 'share_album_request.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-MediaItem _$MediaItemFromJson(Map<String, dynamic> json) {
-  return MediaItem(
-    json['id'] as String,
-    json['description'] as String?,
-    json['productUrl'] as String?,
-    json['baseUrl'] as String?,
-  );
-}
-
-Map<String, dynamic> _$MediaItemToJson(MediaItem instance) {
-  final val = <String, dynamic>{
-    'id': instance.id,
-  };
+Map<String, dynamic> _$ShareAlbumRequestToJson(ShareAlbumRequest instance) {
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -42,8 +31,6 @@ Map<String, dynamic> _$MediaItemToJson(MediaItem instance) {
     }
   }
 
-  writeNotNull('description', instance.description);
-  writeNotNull('productUrl', instance.productUrl);
-  writeNotNull('baseUrl', instance.baseUrl);
+  writeNotNull('sharedAlbumOptions', instance.sharedAlbumOptions);
   return val;
 }

--- a/photos-sharing/initial/lib/photos_library_api/share_album_response.g.dart
+++ b/photos-sharing/initial/lib/photos_library_api/share_album_response.g.dart
@@ -30,7 +30,15 @@ ShareAlbumResponse _$ShareAlbumResponseFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$ShareAlbumResponseToJson(ShareAlbumResponse instance) =>
-    <String, dynamic>{
-      'shareInfo': instance.shareInfo,
-    };
+Map<String, dynamic> _$ShareAlbumResponseToJson(ShareAlbumResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('shareInfo', instance.shareInfo);
+  return val;
+}


### PR DESCRIPTION
Change the json_serializer options to omit `null` parameters during encoding  to match the expected behaviour of the Google Photos Library API. 

Also enable collaborators (who have joined an album) to add photos. This is done by setting the `isCollaborative` flag in the `sharedAlbumOptions` for the album share call. 