### PR TITLE
Disable beta until it catches up with stable

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -20,7 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter_version: [stable, beta]
+        # Disable until beta catches up with stable
+        # flutter_version: [stable, beta]
+        flutter_version: [stable]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The Flutter beta channel is currently behind Flutter stable channel. The code generated by the Flutter stable channel requires at least Dart 2.15.0, which fails on Flutter beta.

This PR can be reverted once Flutter beta channel is running with Dart 2.16.0-0.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat