### PR TITLE
`webview_flutter`: add `setCookie` to step 11

### DIFF
--- a/webview_flutter/step_11/lib/src/menu.dart
+++ b/webview_flutter/step_11/lib/src/menu.dart
@@ -9,6 +9,7 @@ enum _MenuOptions {
   listCookies,
   clearCookies,
   addCookie,
+  setCookie,
   removeCookie,
 }
 
@@ -65,6 +66,9 @@ req.send();''');
               case _MenuOptions.addCookie:
                 _onAddCookie(controller.data!);
                 break;
+              case _MenuOptions.setCookie:
+                _onSetCookie(controller.data!);
+                break;
               case _MenuOptions.removeCookie:
                 _onRemoveCookie(controller.data!);
                 break;
@@ -94,6 +98,10 @@ req.send();''');
             const PopupMenuItem<_MenuOptions>(
               value: _MenuOptions.addCookie,
               child: Text('Add cookie'),
+            ),
+            const PopupMenuItem<_MenuOptions>(
+              value: _MenuOptions.setCookie,
+              child: Text('Set cookie'),
             ),
             const PopupMenuItem<_MenuOptions>(
               value: _MenuOptions.removeCookie,
@@ -135,6 +143,19 @@ req.send();''');
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(
         content: Text('Custom cookie added.'),
+      ),
+    );
+  }
+
+  Future<void> _onSetCookie(
+      WebViewController controller) async {
+    await cookieManager.setCookie(
+      const WebViewCookie(
+          name: 'foo', value: 'bar', domain: 'flutter.dev'),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Custom cookie is set.'),
       ),
     );
   }

--- a/webview_flutter/step_11/lib/src/menu.dart
+++ b/webview_flutter/step_11/lib/src/menu.dart
@@ -147,11 +147,9 @@ req.send();''');
     );
   }
 
-  Future<void> _onSetCookie(
-      WebViewController controller) async {
+  Future<void> _onSetCookie(WebViewController controller) async {
     await cookieManager.setCookie(
-      const WebViewCookie(
-          name: 'foo', value: 'bar', domain: 'flutter.dev'),
+      const WebViewCookie(name: 'foo', value: 'bar', domain: 'flutter.dev'),
     );
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(


### PR DESCRIPTION
Updated step 11: Added the `_onSetCookie` method which uses the recently added `setCookie` method from the `CookieManager` class.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat