### PR TITLE
Fix ignored status and update product status correctly

### DIFF
--- a/in_app_purchases/complete/app/lib/logic/dash_purchases.dart
+++ b/in_app_purchases/complete/app/lib/logic/dash_purchases.dart
@@ -184,8 +184,8 @@ class DashPurchases extends ChangeNotifier {
   }
 
   void _updateStatus(PurchasableProduct product, ProductStatus status) {
-    if (product.status != ProductStatus.purchased) {
-      product.status = ProductStatus.purchased;
+    if (product.status != status) {
+      product.status = status;
       notifyListeners();
     }
   }


### PR DESCRIPTION
In case the there is an active subscription `_updateStatus(element, ProductStatus.purchased); ` did not reflect that in the product status and if there was no active subscription the product status was updated to purchased.

I updated the method so based on the status that is handed in the product gets updated accordingly. 

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat