### PR TITLE
line 19: remove `const` before MaterialApp

### DIFF
--- a/startup_namer/step6_add_interactivity/lib/main.dart
+++ b/startup_namer/step6_add_interactivity/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
   // #docregion build
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       title: 'Startup Name Generator',
       home: RandomWords(),
     );


### PR DESCRIPTION
I was following the tutorials but I get the error " you can not invoke const..." I checked thoroughly to confirm my code is exactly like this one but the error couldnt go and the app failed to load. I checked stack overflow and I luckily found out that all I have to do is remove the const. I know there could be a better and more technical way to put this out, but I'm only a beginner. Hoping for your response, thank you for the lessons

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. For larger changes, raising an issue first helps
reduce redundant work.*

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat