### PR TITLE
chore: Added docregions to startup_names

### DIFF
--- a/startup_namer/step4_infinite_list/lib/main.dart
+++ b/startup_namer/step4_infinite_list/lib/main.dart
@@ -38,7 +38,7 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
       ),
-      #docregion itemBuilder
+      // #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -48,17 +48,17 @@ class _RandomWordsState extends State<RandomWords> {
           if (index >= _suggestions.length) {
             _suggestions.addAll(generateWordPairs().take(10)); /*4*/
           }
-          #docregion listTile
+          // #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
               style: _biggerFont,
             ),
           );
-          #enddocregion listTile
+          // #enddocregion listTile
         },
       ),
-      #enddocregion itemBuilder
+      // #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step4_infinite_list/lib/main.dart
+++ b/startup_namer/step4_infinite_list/lib/main.dart
@@ -38,6 +38,7 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
       ),
+      #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -47,14 +48,17 @@ class _RandomWordsState extends State<RandomWords> {
           if (index >= _suggestions.length) {
             _suggestions.addAll(generateWordPairs().take(10)); /*4*/
           }
+          #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
               style: _biggerFont,
             ),
           );
+          #enddocregion listTile
         },
       ),
+      #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step5_add_icons/lib/main.dart
+++ b/startup_namer/step5_add_icons/lib/main.dart
@@ -39,6 +39,7 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
       ),
+      #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -51,6 +52,7 @@ class _RandomWordsState extends State<RandomWords> {
 
           final alreadySaved = _saved.contains(_suggestions[index]);
 
+          #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
@@ -62,8 +64,10 @@ class _RandomWordsState extends State<RandomWords> {
               semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
             ),
           );
+          #enddocregion listTile
         },
       ),
+      #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step5_add_icons/lib/main.dart
+++ b/startup_namer/step5_add_icons/lib/main.dart
@@ -39,7 +39,7 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
       ),
-      #docregion itemBuilder
+      // #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -52,7 +52,7 @@ class _RandomWordsState extends State<RandomWords> {
 
           final alreadySaved = _saved.contains(_suggestions[index]);
 
-          #docregion listTile
+          // #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
@@ -64,10 +64,10 @@ class _RandomWordsState extends State<RandomWords> {
               semanticLabel: alreadySaved ? 'Remove from saved' : 'Save',
             ),
           );
-          #enddocregion listTile
+          // #enddocregion listTile
         },
       ),
-      #enddocregion itemBuilder
+      // #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step6_add_interactivity/lib/main.dart
+++ b/startup_namer/step6_add_interactivity/lib/main.dart
@@ -39,7 +39,7 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
       ),
-      #docregion itemBuilder
+      // #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -52,7 +52,7 @@ class _RandomWordsState extends State<RandomWords> {
 
           final alreadySaved = _saved.contains(_suggestions[index]);
 
-          #docregion listTile
+          // #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
@@ -73,10 +73,10 @@ class _RandomWordsState extends State<RandomWords> {
               });
             },
           );
-          #enddocregion listTile
+          // #enddocregion listTile
         },
       ),
-      #enddocregion itemBuilder
+      // #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step6_add_interactivity/lib/main.dart
+++ b/startup_namer/step6_add_interactivity/lib/main.dart
@@ -39,6 +39,7 @@ class _RandomWordsState extends State<RandomWords> {
       appBar: AppBar(
         title: const Text('Startup Name Generator'),
       ),
+      #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -51,6 +52,7 @@ class _RandomWordsState extends State<RandomWords> {
 
           final alreadySaved = _saved.contains(_suggestions[index]);
 
+          #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
@@ -71,8 +73,10 @@ class _RandomWordsState extends State<RandomWords> {
               });
             },
           );
+          #enddocregion listTile
         },
       ),
+      #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step7_navigate_route/lib/main.dart
+++ b/startup_namer/step7_navigate_route/lib/main.dart
@@ -46,7 +46,7 @@ class _RandomWordsState extends State<RandomWords> {
           ),
         ],
       ),
-      #docregion itemBuilder
+      // #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -59,7 +59,7 @@ class _RandomWordsState extends State<RandomWords> {
 
           final alreadySaved = _saved.contains(_suggestions[index]);
 
-          #docregion listTile
+          // #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
@@ -80,10 +80,10 @@ class _RandomWordsState extends State<RandomWords> {
               });
             },
           );
-          #enddocregion listTile
+          // #enddocregion listTile
         },
       ),
-      #enddocregion itemBuilder
+      // #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step7_navigate_route/lib/main.dart
+++ b/startup_namer/step7_navigate_route/lib/main.dart
@@ -46,6 +46,7 @@ class _RandomWordsState extends State<RandomWords> {
           ),
         ],
       ),
+      #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -58,6 +59,7 @@ class _RandomWordsState extends State<RandomWords> {
 
           final alreadySaved = _saved.contains(_suggestions[index]);
 
+          #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
@@ -78,8 +80,10 @@ class _RandomWordsState extends State<RandomWords> {
               });
             },
           );
+          #enddocregion listTile
         },
       ),
+      #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step8_themes/lib/main.dart
+++ b/startup_namer/step8_themes/lib/main.dart
@@ -52,6 +52,7 @@ class _RandomWordsState extends State<RandomWords> {
           ),
         ],
       ),
+      #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -64,6 +65,7 @@ class _RandomWordsState extends State<RandomWords> {
 
           final alreadySaved = _saved.contains(_suggestions[index]);
 
+          #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
@@ -84,8 +86,10 @@ class _RandomWordsState extends State<RandomWords> {
               });
             },
           );
+          #enddocregion listTile
         },
       ),
+      #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build

--- a/startup_namer/step8_themes/lib/main.dart
+++ b/startup_namer/step8_themes/lib/main.dart
@@ -52,7 +52,7 @@ class _RandomWordsState extends State<RandomWords> {
           ),
         ],
       ),
-      #docregion itemBuilder
+      // #docregion itemBuilder
       body: ListView.builder(
         padding: const EdgeInsets.all(16.0),
         itemBuilder: /*1*/ (context, i) {
@@ -65,7 +65,7 @@ class _RandomWordsState extends State<RandomWords> {
 
           final alreadySaved = _saved.contains(_suggestions[index]);
 
-          #docregion listTile
+          // #docregion listTile
           return ListTile(
             title: Text(
               _suggestions[index].asPascalCase,
@@ -86,10 +86,10 @@ class _RandomWordsState extends State<RandomWords> {
               });
             },
           );
-          #enddocregion listTile
+          // #enddocregion listTile
         },
       ),
-      #enddocregion itemBuilder
+      // #enddocregion itemBuilder
     );
   }
   // #enddocregion RWS-build


### PR DESCRIPTION
In order to correctly refresh code excerpts for https://github.com/flutter/website/pull/6817 we need some extra docregions.

Since we've removed the old ones (`_buildSuggestions` and `_buildRow`) we need new ones to reference the widget that replaced the functions

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].