### PR TITLE
Remove forgotten comment - github-client

### DIFF
--- a/github-client/step_07/lib/main.dart
+++ b/github-client/step_07/lib/main.dart
@@ -48,7 +48,7 @@ class MyHomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return GithubLoginWidget(
       builder: (context, httpClient) {
-        WindowToFront.activate(); // and this.
+        WindowToFront.activate();
         return Scaffold(
           appBar: AppBar(
             title: Text(title),


### PR DESCRIPTION
In a previous step, there were two comments that said "Add this" and then on another line "and this".  It looks like someone removed the first one but missed the second.