### PR TITLE
Fix url_launcher warnings

### DIFF
--- a/github-client/step_04/lib/src/github_login.dart
+++ b/github-client/step_04/lib/src/github_login.dart
@@ -16,7 +16,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 final _authorizationEndpoint =
     Uri.parse('https://github.com/login/oauth/authorize');
@@ -100,8 +100,8 @@ class _GithubLoginState extends State<GithubLoginWidget> {
 
   Future<void> _redirect(Uri authorizationUrl) async {
     var url = authorizationUrl.toString();
-    if (await canLaunch(url)) {
-      await launch(url);
+    if (await canLaunchUrlString(url)) {
+      await launchUrlString(url);
     } else {
       throw GithubLoginException('Could not launch $url');
     }

--- a/github-client/step_05/lib/src/github_login.dart
+++ b/github-client/step_05/lib/src/github_login.dart
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 final _authorizationEndpoint =
     Uri.parse('https://github.com/login/oauth/authorize');
@@ -100,8 +101,8 @@ class _GithubLoginState extends State<GithubLoginWidget> {
 
   Future<void> _redirect(Uri authorizationUrl) async {
     var url = authorizationUrl.toString();
-    if (await canLaunch(url)) {
-      await launch(url);
+    if (await canLaunchUrlString(url)) {
+      await launchUrlString(url);
     } else {
       throw GithubLoginException('Could not launch $url');
     }

--- a/github-client/step_06/lib/src/github_login.dart
+++ b/github-client/step_06/lib/src/github_login.dart
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 final _authorizationEndpoint =
     Uri.parse('https://github.com/login/oauth/authorize');
@@ -100,8 +101,8 @@ class _GithubLoginState extends State<GithubLoginWidget> {
 
   Future<void> _redirect(Uri authorizationUrl) async {
     var url = authorizationUrl.toString();
-    if (await canLaunch(url)) {
-      await launch(url);
+    if (await canLaunchUrlString(url)) {
+      await launchUrlString(url);
     } else {
       throw GithubLoginException('Could not launch $url');
     }

--- a/github-client/step_07/lib/src/github_login.dart
+++ b/github-client/step_07/lib/src/github_login.dart
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart' as oauth2;
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 final _authorizationEndpoint =
     Uri.parse('https://github.com/login/oauth/authorize');
@@ -100,8 +101,8 @@ class _GithubLoginState extends State<GithubLoginWidget> {
 
   Future<void> _redirect(Uri authorizationUrl) async {
     var url = authorizationUrl.toString();
-    if (await canLaunch(url)) {
-      await launch(url);
+    if (await canLaunchUrlString(url)) {
+      await launchUrlString(url);
     } else {
       throw GithubLoginException('Could not launch $url');
     }

--- a/github-client/step_07/lib/src/github_summary.dart
+++ b/github-client/step_07/lib/src/github_summary.dart
@@ -15,7 +15,7 @@
 import 'package:flutter/material.dart';
 import 'package:fluttericon/octicons_icons.dart';
 import 'package:github/github.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 class GitHubSummary extends StatefulWidget {
   const GitHubSummary({required this.gitHub, Key? key}) : super(key: key);
@@ -224,8 +224,8 @@ class _PullRequestsListState extends State<PullRequestsList> {
 }
 
 Future<void> _launchUrl(BuildContext context, String url) async {
-  if (await canLaunch(url)) {
-    await launch(url);
+  if (await canLaunchUrlString(url)) {
+    await launchUrlString(url);
   } else {
     return showDialog(
       context: context,


### PR DESCRIPTION
Dependabot appears to have pulled in a new version of url_launcher, which causes analysis warnings. This fails the master branch as well as PRs, such as #512.

This PR provides a quick fix, using the new non-deprecated methods to launch a URL string. However, I'm not quite sure if these changes will be reflected at the codelab itself once pushed to master, or if something needs to be changed somewhere else? https://codelabs.developers.google.com/codelabs/flutter-github-client/

It may also be good to check the dependabot setup. I'm kinda surprised it was able to merge an updated dependency that caused analysis errors which break master.

## Pre-launch Checklist

- [X] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
