### PR TITLE
Add Mac network.client entitlements to TF Serving codelab

### DIFF
--- a/tfserving-flutter/codelab2/finished/macos/Runner/DebugProfile.entitlements
+++ b/tfserving-flutter/codelab2/finished/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/tfserving-flutter/codelab2/finished/macos/Runner/Release.entitlements
+++ b/tfserving-flutter/codelab2/finished/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/tfserving-flutter/codelab2/starter/macos/Runner/DebugProfile.entitlements
+++ b/tfserving-flutter/codelab2/starter/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/tfserving-flutter/codelab2/starter/macos/Runner/Release.entitlements
+++ b/tfserving-flutter/codelab2/starter/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
With the entitlements the app cannot send requests to TF Serving on Mac.