### PR TITLE
add back theme provider comments

### DIFF
--- a/boring_to_beautiful/step_01/lib/src/shared/providers/theme.dart
+++ b/boring_to_beautiful/step_01/lib/src/shared/providers/theme.dart
@@ -149,7 +149,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData light([Color? targetColor]) {
     final colorScheme = colors(Brightness.light, targetColor);
     return ThemeData.light().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),
@@ -167,7 +167,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData dark([Color? targetColor]) {
     final colorScheme = colors(Brightness.dark, targetColor);
     return ThemeData.dark().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),

--- a/boring_to_beautiful/step_02/lib/src/shared/providers/theme.dart
+++ b/boring_to_beautiful/step_02/lib/src/shared/providers/theme.dart
@@ -149,7 +149,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData light([Color? targetColor]) {
     final colorScheme = colors(Brightness.light, targetColor);
     return ThemeData.light().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),
@@ -167,7 +167,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData dark([Color? targetColor]) {
     final colorScheme = colors(Brightness.dark, targetColor);
     return ThemeData.dark().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),

--- a/boring_to_beautiful/step_03/lib/src/shared/providers/theme.dart
+++ b/boring_to_beautiful/step_03/lib/src/shared/providers/theme.dart
@@ -149,7 +149,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData light([Color? targetColor]) {
     final colorScheme = colors(Brightness.light, targetColor);
     return ThemeData.light().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),
@@ -167,7 +167,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData dark([Color? targetColor]) {
     final colorScheme = colors(Brightness.dark, targetColor);
     return ThemeData.dark().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),

--- a/boring_to_beautiful/step_04/lib/src/shared/providers/theme.dart
+++ b/boring_to_beautiful/step_04/lib/src/shared/providers/theme.dart
@@ -149,7 +149,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData light([Color? targetColor]) {
     final colorScheme = colors(Brightness.light, targetColor);
     return ThemeData.light().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),
@@ -167,7 +167,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData dark([Color? targetColor]) {
     final colorScheme = colors(Brightness.dark, targetColor);
     return ThemeData.dark().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),

--- a/boring_to_beautiful/step_05/lib/src/shared/providers/theme.dart
+++ b/boring_to_beautiful/step_05/lib/src/shared/providers/theme.dart
@@ -149,7 +149,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData light([Color? targetColor]) {
     final colorScheme = colors(Brightness.light, targetColor);
     return ThemeData.light().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),
@@ -167,7 +167,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData dark([Color? targetColor]) {
     final colorScheme = colors(Brightness.dark, targetColor);
     return ThemeData.dark().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),

--- a/boring_to_beautiful/step_06/lib/src/shared/providers/theme.dart
+++ b/boring_to_beautiful/step_06/lib/src/shared/providers/theme.dart
@@ -149,7 +149,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData light([Color? targetColor]) {
     final colorScheme = colors(Brightness.light, targetColor);
     return ThemeData.light().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),
@@ -167,7 +167,7 @@ class ThemeProvider extends InheritedWidget {
   ThemeData dark([Color? targetColor]) {
     final colorScheme = colors(Brightness.dark, targetColor);
     return ThemeData.dark().copyWith(
-      pageTransitionsTheme: pageTransitionsTheme,
+      // Add page transitions
       colorScheme: colorScheme,
       appBarTheme: appBarTheme(colorScheme),
       cardTheme: cardTheme(),


### PR DESCRIPTION
[Boring to Beautiful step 6](https://codelabs.developers.google.com/codelabs/flutter-boring-to-beautiful#6) instructs users to add the pageTransitionsTheme, but #816 seems already adds it for them. This just replaces `pageTransitionsTheme: pageTransitionsTheme` with a placeholder comment for steps where it's supposed to be blank. 

*List which issues are fixed by this PR. For larger changes, raising an issue first helps
reduce redundant work.* Addresses one of the issues mentioned in https://github.com/flutter/flutter/issues/105017

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
