### PR TITLE
Adjust startup namer itembuilder doc region

### DIFF
--- a/startup_namer/step4_infinite_list/lib/main.dart
+++ b/startup_namer/step4_infinite_list/lib/main.dart
@@ -60,8 +60,8 @@ class _RandomWordsState extends State<RandomWords> {
         );
         // #enddocregion listTile
       },
-      // #enddocregion itemBuilder
     );
+    // #enddocregion itemBuilder
   }
   // #enddocregion RWS-build
   // #docregion RWS-var

--- a/startup_namer/step5_add_icons/lib/main.dart
+++ b/startup_namer/step5_add_icons/lib/main.dart
@@ -69,8 +69,8 @@ class _RandomWordsState extends State<RandomWords> {
         );
         // #enddocregion listTile
       },
-      // #enddocregion itemBuilder
     );
+    // #enddocregion itemBuilder
   }
   // #enddocregion RWS-build
   // #docregion RWS-var


### PR DESCRIPTION
The closing parentheses for the ListView.builder call were being cut off in the excerpts

Blocks: https://github.com/flutter/website/pull/7254

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.