### PR TITLE
Fix crash due to missing RouteInformationProvider.

### DIFF
--- a/boring_to_beautiful/final/lib/src/shared/app.dart
+++ b/boring_to_beautiful/final/lib/src/shared/app.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
+                    routeInformationProvider: appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/final/lib/src/shared/app.dart
+++ b/boring_to_beautiful/final/lib/src/shared/app.dart
@@ -43,7 +43,8 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
-                    routeInformationProvider: appRouter.routeInformationProvider,
+                    routeInformationProvider:
+                        appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_01/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_01/lib/src/shared/app.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
                     // Add dark theme
                     // Add theme mode
                     routeInformationParser: appRouter.routeInformationParser,
+                    routeInformationProvider: appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_01/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_01/lib/src/shared/app.dart
@@ -43,7 +43,8 @@ class _MyAppState extends State<MyApp> {
                     // Add dark theme
                     // Add theme mode
                     routeInformationParser: appRouter.routeInformationParser,
-                    routeInformationProvider: appRouter.routeInformationProvider,
+                    routeInformationProvider:
+                        appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_02/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_02/lib/src/shared/app.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
                     // Add dark theme
                     // Add theme mode
                     routeInformationParser: appRouter.routeInformationParser,
+                    routeInformationProvider: appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_02/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_02/lib/src/shared/app.dart
@@ -43,7 +43,8 @@ class _MyAppState extends State<MyApp> {
                     // Add dark theme
                     // Add theme mode
                     routeInformationParser: appRouter.routeInformationParser,
-                    routeInformationProvider: appRouter.routeInformationProvider,
+                    routeInformationProvider:
+                        appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_03/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_03/lib/src/shared/app.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
                     // Add dark theme
                     // Add theme mode
                     routeInformationParser: appRouter.routeInformationParser,
+                    routeInformationProvider: appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_03/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_03/lib/src/shared/app.dart
@@ -43,7 +43,8 @@ class _MyAppState extends State<MyApp> {
                     // Add dark theme
                     // Add theme mode
                     routeInformationParser: appRouter.routeInformationParser,
-                    routeInformationProvider: appRouter.routeInformationProvider,
+                    routeInformationProvider:
+                        appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_04/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_04/lib/src/shared/app.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
+                    routeInformationProvider: appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_04/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_04/lib/src/shared/app.dart
@@ -43,7 +43,8 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
-                    routeInformationProvider: appRouter.routeInformationProvider,
+                    routeInformationProvider:
+                        appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_05/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_05/lib/src/shared/app.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
+                    routeInformationProvider: appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_05/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_05/lib/src/shared/app.dart
@@ -43,7 +43,8 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
-                    routeInformationProvider: appRouter.routeInformationProvider,
+                    routeInformationProvider:
+                        appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_06/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_06/lib/src/shared/app.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
+                    routeInformationProvider: appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_06/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_06/lib/src/shared/app.dart
@@ -43,7 +43,8 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
-                    routeInformationProvider: appRouter.routeInformationProvider,
+                    routeInformationProvider:
+                        appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_07/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_07/lib/src/shared/app.dart
@@ -43,6 +43,7 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
+                    routeInformationProvider: appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },

--- a/boring_to_beautiful/step_07/lib/src/shared/app.dart
+++ b/boring_to_beautiful/step_07/lib/src/shared/app.dart
@@ -43,7 +43,8 @@ class _MyAppState extends State<MyApp> {
                     darkTheme: theme.dark(settings.value.sourceColor),
                     themeMode: theme.themeMode(),
                     routeInformationParser: appRouter.routeInformationParser,
-                    routeInformationProvider: appRouter.routeInformationProvider,
+                    routeInformationProvider:
+                        appRouter.routeInformationProvider,
                     routerDelegate: appRouter.routerDelegate,
                   );
                 },


### PR DESCRIPTION
Boring to Beautiful app crashes at launch because `GoRouter` requires passing `routeInformationProvider` to `MaterialApp.router` when using `routeInformationParser`.

This patch adds a single line to the `app.dart` file in each step, passing `appRouter.routeInformationProvider` to `MaterialApp.router`.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
