### PR TITLE
Compat fix for working with firebase_ui library

### DIFF
--- a/firebase-get-to-know-flutter/step_02/android/app/build.gradle
+++ b/firebase-get-to-know-flutter/step_02/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.example.gtk_flutter"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/firebase-get-to-know-flutter/step_04/android/app/build.gradle
+++ b/firebase-get-to-know-flutter/step_04/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.example.gtk_flutter"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/firebase-get-to-know-flutter/step_05/android/app/build.gradle
+++ b/firebase-get-to-know-flutter/step_05/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.example.gtk_flutter"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/firebase-get-to-know-flutter/step_06/android/app/build.gradle
+++ b/firebase-get-to-know-flutter/step_06/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.example.gtk_flutter"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/firebase-get-to-know-flutter/step_07/android/app/build.gradle
+++ b/firebase-get-to-know-flutter/step_07/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.example.gtk_flutter"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/firebase-get-to-know-flutter/step_09/android/app/build.gradle
+++ b/firebase-get-to-know-flutter/step_09/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.example.gtk_flutter"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Sets default minSDk for working with firebase_ui library. The Android compilation step will throw an error otherwise.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
