### PR TITLE
Drop `docregion`s from `pubspec.yaml`

### DIFF
--- a/startup_namer/codelab_rebuild.yaml
+++ b/startup_namer/codelab_rebuild.yaml
@@ -91,11 +91,9 @@ steps:
           environment:
             sdk: '>=2.18.0 <3.0.0'
           
-          # #docregion dependencies
           dependencies:
             flutter:
               sdk: flutter
-          # #enddocregion dependencies
           
           dev_dependencies:
             flutter_test:
@@ -188,25 +186,6 @@ steps:
     steps:
       - name: Remove step3_stateful_widget
         rmdir: step3_stateful_widget
-      - name: Patch pubspec.yaml
-        path: startup_namer/pubspec.yaml
-        patch-u: |
-          --- b/startup_namer/step3_stateful_widget/pubspec.yaml
-          +++ a/startup_namer/step3_stateful_widget/pubspec.yaml
-          @@ -6,13 +6,11 @@ version: 1.0.0+1
-           environment:
-             sdk: '>=2.18.0 <3.0.0'
-           
-          -# #docregion dependencies
-           dependencies:
-             cupertino_icons: ^1.0.5
-             english_words: ^4.0.0
-             flutter:
-               sdk: flutter
-          -# #enddocregion dependencies
-           
-           dev_dependencies:
-             flutter_lints: ^2.0.1
       - name: Patch lib/main.dart
         path: startup_namer/lib/main.dart
         patch-u: |

--- a/startup_namer/step1_base/pubspec.yaml
+++ b/startup_namer/step1_base/pubspec.yaml
@@ -6,12 +6,10 @@ version: 1.0.0+1
 environment:
   sdk: '>=2.18.0 <3.0.0'
 
-# #docregion dependencies
 dependencies:
   cupertino_icons: ^1.0.5
   flutter:
     sdk: flutter
-# #enddocregion dependencies
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/startup_namer/step2_use_package/pubspec.yaml
+++ b/startup_namer/step2_use_package/pubspec.yaml
@@ -6,13 +6,11 @@ version: 1.0.0+1
 environment:
   sdk: '>=2.18.0 <3.0.0'
 
-# #docregion dependencies
 dependencies:
   cupertino_icons: ^1.0.5
   english_words: ^4.0.0
   flutter:
     sdk: flutter
-# #enddocregion dependencies
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
They aren't actually used.

This change will make `startup_namer`'s rebuild script stable on Flutter version change.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
