### PR TITLE
fix Render Box return null if the root child of Shimmer not a scrollable

### DIFF
--- a/cookbook/lib/examples/ui_loading_animation.dart
+++ b/cookbook/lib/examples/ui_loading_animation.dart
@@ -155,7 +155,7 @@ class ShimmerState extends State<Shimmer> with SingleTickerProviderStateMixin {
             _SlidingGradientTransform(slidePercent: _shimmerController.value),
       );
 
-  bool get isSized => (context.findRenderObject() as RenderBox).hasSize;
+  bool get isSized => (context.findRenderObject() as RenderBox?)?.hasSize ?? false;
 
   Size get size => (context.findRenderObject() as RenderBox).size;
 


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*Fix error when root child of Shimmer is not a scrollable