### PR TITLE
A11y changes

### DIFF
--- a/startup_namer/step3_stateful_widget/test/widget_test.dart
+++ b/startup_namer/step3_stateful_widget/test/widget_test.dart
@@ -21,5 +21,22 @@ void main() {
     final wordPairRegExp = RegExp(r'^[A-Z]\w*[A-Z]\w*$');
     final isWordPair = predicate<String>((s) => wordPairRegExp.hasMatch(s));
     expect(textWidgets.first.data, isWordPair);
+
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(const MaterialApp(home: MyApp()));
+
+    // Checks that tappable nodes have a minimum size of 48 by 48 pixels for android.
+    await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+
+    // Checks that tappable nodes have a minimum size of 44 by 44 pixels for iOS.
+    await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+
+    // Checks that touch targets with a tap or long press action are labeled.
+    await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+
+    // Checks whether semantic nodes meet the minimum text contrast levels.
+    // The recommended text contrast is 3:1 for larger text (18 point and above regular)
+    await expectLater(tester, meetsGuideline(textContrastGuideline));
+    handle.dispose();
   });
 }

--- a/startup_namer/step3_stateful_widget/test/widget_test.dart
+++ b/startup_namer/step3_stateful_widget/test/widget_test.dart
@@ -22,6 +22,7 @@ void main() {
     final isWordPair = predicate<String>((s) => wordPairRegExp.hasMatch(s));
     expect(textWidgets.first.data, isWordPair);
 
+    // #docregion a11yAPI
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(const MaterialApp(home: MyApp()));
 
@@ -38,5 +39,6 @@ void main() {
     // The recommended text contrast is 3:1 for larger text (18 point and above regular)
     await expectLater(tester, meetsGuideline(textContrastGuideline));
     handle.dispose();
+    // #enddocregion a11yAPI
   });
 }


### PR DESCRIPTION
Added start/end markers for AccessibilityGuideline API unit tests in widget_test.dart. 

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
