### PR TITLE
firebase-get-to-know-flutter: add go_router

### DIFF
--- a/firebase-get-to-know-flutter/step_02/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_02/lib/src/authentication.dart
@@ -25,9 +25,7 @@ class AuthFunc extends StatelessWidget {
           padding: const EdgeInsets.only(left: 24, bottom: 8),
           child: StyledButton(
               onPressed: () {
-                !loggedIn
-                    ? context.push('/sign-in')
-                    : signOut();
+                !loggedIn ? context.push('/sign-in') : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
         ),

--- a/firebase-get-to-know-flutter/step_02/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_02/lib/src/authentication.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'widgets.dart';
 
@@ -25,7 +26,7 @@ class AuthFunc extends StatelessWidget {
           child: StyledButton(
               onPressed: () {
                 !loggedIn
-                    ? Navigator.of(context).pushNamed('/sign-in')
+                    ? context.push('/sign-in')
                     : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
@@ -36,7 +37,7 @@ class AuthFunc extends StatelessWidget {
               padding: const EdgeInsets.only(left: 24, bottom: 8),
               child: StyledButton(
                   onPressed: () {
-                    Navigator.of(context).pushNamed('/profile');
+                    context.push('/profile');
                   },
                   child: const Text('Profile')),
             ))

--- a/firebase-get-to-know-flutter/step_02/pubspec.yaml
+++ b/firebase-get-to-know-flutter/step_02/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   google_fonts: ^3.0.1
+  go_router: ^5.2.1
 
 dev_dependencies:
   flutter_test:

--- a/firebase-get-to-know-flutter/step_04/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_04/lib/src/authentication.dart
@@ -25,9 +25,7 @@ class AuthFunc extends StatelessWidget {
           padding: const EdgeInsets.only(left: 24, bottom: 8),
           child: StyledButton(
               onPressed: () {
-                !loggedIn
-                    ? context.push('/sign-in')
-                    : signOut();
+                !loggedIn ? context.push('/sign-in') : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
         ),

--- a/firebase-get-to-know-flutter/step_04/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_04/lib/src/authentication.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'widgets.dart';
 
@@ -25,7 +26,7 @@ class AuthFunc extends StatelessWidget {
           child: StyledButton(
               onPressed: () {
                 !loggedIn
-                    ? Navigator.of(context).pushNamed('/sign-in')
+                    ? context.push('/sign-in')
                     : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
@@ -36,7 +37,7 @@ class AuthFunc extends StatelessWidget {
               padding: const EdgeInsets.only(left: 24, bottom: 8),
               child: StyledButton(
                   onPressed: () {
-                    Navigator.of(context).pushNamed('/profile');
+                    context.push('/profile');
                   },
                   child: const Text('Profile')),
             ))

--- a/firebase-get-to-know-flutter/step_04/pubspec.yaml
+++ b/firebase-get-to-know-flutter/step_04/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   google_fonts: ^3.0.1
+  go_router: ^5.2.1
   cloud_firestore: ^4.1.0
   firebase_auth: ^4.1.4
   firebase_core: ^2.3.0

--- a/firebase-get-to-know-flutter/step_05/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_05/lib/main.dart
@@ -4,6 +4,7 @@
 
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
@@ -19,70 +20,87 @@ void main() {
   ));
 }
 
+final _router = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const HomePage(),
+      routes: [
+        GoRoute(
+          path: 'sign-in',
+          builder: (context, state) {
+            return SignInScreen(
+              actions: [
+                ForgotPasswordAction(((context, email) {
+                  final uri = Uri(
+                    path: '/sign-in/forgot-password',
+                    queryParameters: <String, String?>{
+                      'email': email,
+                    },
+                  );
+                  context.push(uri.toString());
+                })),
+                AuthStateChangeAction(((context, state) {
+                  if (state is SignedIn || state is UserCreated) {
+                    var user = (state is SignedIn)
+                        ? state.user
+                        : (state as UserCreated).credential.user;
+                    if (user == null) {
+                      return;
+                    }
+                    if (state is UserCreated) {
+                      user.updateDisplayName(user.email!.split('@')[0]);
+                    }
+                    if (!user.emailVerified) {
+                      user.sendEmailVerification();
+                      const snackBar = SnackBar(
+                          content: Text(
+                              'Please check your email to verify your email address'));
+                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                    }
+                    context.replace('/');
+                  }
+                })),
+              ],
+            );
+          },
+          routes: [
+            GoRoute(
+              path: 'forgot-password',
+              builder: (context, state) {
+                final arguments = state.queryParams;
+                return ForgotPasswordScreen(
+                  email: arguments['email'],
+                  headerMaxExtent: 200,
+                );
+              },
+            ),
+          ],
+        ),
+        GoRoute(
+          path: 'profile',
+          builder: (context, state) {
+            return ProfileScreen(
+              providers: const [],
+              actions: [
+                SignedOutAction((context) {
+                  context.replace('/');
+                }),
+              ],
+            );
+          },
+        ),
+      ],
+    ),
+  ],
+);
+
 class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      initialRoute: '/home',
-      routes: {
-        '/home': (context) {
-          return const HomePage();
-        },
-        '/sign-in': ((context) {
-          return SignInScreen(
-            actions: [
-              ForgotPasswordAction(((context, email) {
-                Navigator.of(context)
-                    .pushNamed('/forgot-password', arguments: {'email': email});
-              })),
-              AuthStateChangeAction(((context, state) {
-                if (state is SignedIn || state is UserCreated) {
-                  var user = (state is SignedIn)
-                      ? state.user
-                      : (state as UserCreated).credential.user;
-                  if (user == null) {
-                    return;
-                  }
-                  if (state is UserCreated) {
-                    user.updateDisplayName(user.email!.split('@')[0]);
-                  }
-                  if (!user.emailVerified) {
-                    user.sendEmailVerification();
-                    const snackBar = SnackBar(
-                        content: Text(
-                            'Please check your email to verify your email address'));
-                    ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                  }
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                }
-              })),
-            ],
-          );
-        }),
-        '/forgot-password': ((context) {
-          final arguments = ModalRoute.of(context)?.settings.arguments
-              as Map<String, dynamic>?;
-
-          return ForgotPasswordScreen(
-            email: arguments?['email'] as String,
-            headerMaxExtent: 200,
-          );
-        }),
-        '/profile': ((context) {
-          return ProfileScreen(
-            providers: const [],
-            actions: [
-              SignedOutAction(
-                ((context) {
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                }),
-              ),
-            ],
-          );
-        })
-      },
+    return MaterialApp.router(
       title: 'Firebase Meetup',
       theme: ThemeData(
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
@@ -94,6 +112,7 @@ class App extends StatelessWidget {
         ),
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
+      routerConfig: _router,
     );
   }
 }

--- a/firebase-get-to-know-flutter/step_05/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_05/lib/src/authentication.dart
@@ -25,9 +25,7 @@ class AuthFunc extends StatelessWidget {
           padding: const EdgeInsets.only(left: 24, bottom: 8),
           child: StyledButton(
               onPressed: () {
-                !loggedIn
-                    ? context.push('/sign-in')
-                    : signOut();
+                !loggedIn ? context.push('/sign-in') : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
         ),

--- a/firebase-get-to-know-flutter/step_05/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_05/lib/src/authentication.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'widgets.dart';
 
@@ -25,7 +26,7 @@ class AuthFunc extends StatelessWidget {
           child: StyledButton(
               onPressed: () {
                 !loggedIn
-                    ? Navigator.of(context).pushNamed('/sign-in')
+                    ? context.push('/sign-in')
                     : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
@@ -36,7 +37,7 @@ class AuthFunc extends StatelessWidget {
               padding: const EdgeInsets.only(left: 24, bottom: 8),
               child: StyledButton(
                   onPressed: () {
-                    Navigator.of(context).pushNamed('/profile');
+                    context.push('/profile');
                   },
                   child: const Text('Profile')),
             ))

--- a/firebase-get-to-know-flutter/step_05/pubspec.yaml
+++ b/firebase-get-to-know-flutter/step_05/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   google_fonts: ^3.0.1
+  go_router: ^5.2.1
   cloud_firestore: ^4.1.0
   firebase_auth: ^4.1.4
   firebase_core: ^2.3.0

--- a/firebase-get-to-know-flutter/step_06/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_06/lib/main.dart
@@ -4,6 +4,7 @@
 
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
@@ -11,76 +12,95 @@ import 'app_state.dart';
 import 'home_page.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
   runApp(ChangeNotifierProvider(
     create: (context) => ApplicationState(),
     builder: ((context, child) => const App()),
   ));
 }
 
+final _router = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const HomePage(),
+      routes: [
+        GoRoute(
+          path: 'sign-in',
+          builder: (context, state) {
+            return SignInScreen(
+              actions: [
+                ForgotPasswordAction(((context, email) {
+                  final uri = Uri(
+                    path: '/sign-in/forgot-password',
+                    queryParameters: <String, String?>{
+                      'email': email,
+                    },
+                  );
+                  context.push(uri.toString());
+                })),
+                AuthStateChangeAction(((context, state) {
+                  if (state is SignedIn || state is UserCreated) {
+                    var user = (state is SignedIn)
+                        ? state.user
+                        : (state as UserCreated).credential.user;
+                    if (user == null) {
+                      return;
+                    }
+                    if (state is UserCreated) {
+                      user.updateDisplayName(user.email!.split('@')[0]);
+                    }
+                    if (!user.emailVerified) {
+                      user.sendEmailVerification();
+                      const snackBar = SnackBar(
+                          content: Text(
+                              'Please check your email to verify your email address'));
+                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                    }
+                    context.replace('/');
+                  }
+                })),
+              ],
+            );
+          },
+          routes: [
+            GoRoute(
+              path: 'forgot-password',
+              builder: (context, state) {
+                final arguments = state.queryParams;
+                return ForgotPasswordScreen(
+                  email: arguments['email'],
+                  headerMaxExtent: 200,
+                );
+              },
+            ),
+          ],
+        ),
+        GoRoute(
+          path: 'profile',
+          builder: (context, state) {
+            return ProfileScreen(
+              providers: const [],
+              actions: [
+                SignedOutAction((context) {
+                  context.replace('/');
+                }),
+              ],
+            );
+          },
+        ),
+      ],
+    ),
+  ],
+);
+
 class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      initialRoute: '/home',
-      routes: {
-        '/home': (context) {
-          return const HomePage();
-        },
-        '/sign-in': ((context) {
-          return SignInScreen(
-            actions: [
-              ForgotPasswordAction(((context, email) {
-                Navigator.of(context)
-                    .pushNamed('/forgot-password', arguments: {'email': email});
-              })),
-              AuthStateChangeAction(((context, state) {
-                if (state is SignedIn || state is UserCreated) {
-                  var user = (state is SignedIn)
-                      ? state.user
-                      : (state as UserCreated).credential.user;
-                  if (user == null) {
-                    return;
-                  }
-                  if (state is UserCreated) {
-                    user.updateDisplayName(user.email!.split('@')[0]);
-                  }
-                  if (!user.emailVerified) {
-                    user.sendEmailVerification();
-                    const snackBar = SnackBar(
-                        content: Text(
-                            'Please check your email to verify your email address'));
-                    ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                  }
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                }
-              })),
-            ],
-          );
-        }),
-        '/forgot-password': ((context) {
-          final arguments = ModalRoute.of(context)?.settings.arguments
-              as Map<String, dynamic>?;
-
-          return ForgotPasswordScreen(
-            email: arguments?['email'] as String,
-            headerMaxExtent: 200,
-          );
-        }),
-        '/profile': ((context) {
-          return ProfileScreen(
-            providers: const [],
-            actions: [
-              SignedOutAction(
-                ((context) {
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                }),
-              ),
-            ],
-          );
-        })
-      },
+    return MaterialApp.router(
       title: 'Firebase Meetup',
       theme: ThemeData(
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
@@ -92,6 +112,7 @@ class App extends StatelessWidget {
         ),
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
+      routerConfig: _router,
     );
   }
 }

--- a/firebase-get-to-know-flutter/step_06/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_06/lib/src/authentication.dart
@@ -25,9 +25,7 @@ class AuthFunc extends StatelessWidget {
           padding: const EdgeInsets.only(left: 24, bottom: 8),
           child: StyledButton(
               onPressed: () {
-                !loggedIn
-                    ? context.push('/sign-in')
-                    : signOut();
+                !loggedIn ? context.push('/sign-in') : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
         ),

--- a/firebase-get-to-know-flutter/step_06/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_06/lib/src/authentication.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'widgets.dart';
 
@@ -25,7 +26,7 @@ class AuthFunc extends StatelessWidget {
           child: StyledButton(
               onPressed: () {
                 !loggedIn
-                    ? Navigator.of(context).pushNamed('/sign-in')
+                    ? context.push('/sign-in')
                     : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
@@ -36,7 +37,7 @@ class AuthFunc extends StatelessWidget {
               padding: const EdgeInsets.only(left: 24, bottom: 8),
               child: StyledButton(
                   onPressed: () {
-                    Navigator.of(context).pushNamed('/profile');
+                    context.push('/profile');
                   },
                   child: const Text('Profile')),
             ))

--- a/firebase-get-to-know-flutter/step_06/pubspec.yaml
+++ b/firebase-get-to-know-flutter/step_06/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   google_fonts: ^3.0.1
+  go_router: ^5.2.1
   cloud_firestore: ^4.1.0
   firebase_auth: ^4.1.4
   firebase_core: ^2.3.0

--- a/firebase-get-to-know-flutter/step_07/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_07/lib/main.dart
@@ -4,6 +4,7 @@
 
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
@@ -19,70 +20,87 @@ void main() {
   ));
 }
 
+final _router = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const HomePage(),
+      routes: [
+        GoRoute(
+          path: 'sign-in',
+          builder: (context, state) {
+            return SignInScreen(
+              actions: [
+                ForgotPasswordAction(((context, email) {
+                  final uri = Uri(
+                    path: '/sign-in/forgot-password',
+                    queryParameters: <String, String?>{
+                      'email': email,
+                    },
+                  );
+                  context.push(uri.toString());
+                })),
+                AuthStateChangeAction(((context, state) {
+                  if (state is SignedIn || state is UserCreated) {
+                    var user = (state is SignedIn)
+                        ? state.user
+                        : (state as UserCreated).credential.user;
+                    if (user == null) {
+                      return;
+                    }
+                    if (state is UserCreated) {
+                      user.updateDisplayName(user.email!.split('@')[0]);
+                    }
+                    if (!user.emailVerified) {
+                      user.sendEmailVerification();
+                      const snackBar = SnackBar(
+                          content: Text(
+                              'Please check your email to verify your email address'));
+                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                    }
+                    context.replace('/');
+                  }
+                })),
+              ],
+            );
+          },
+          routes: [
+            GoRoute(
+              path: 'forgot-password',
+              builder: (context, state) {
+                final arguments = state.queryParams;
+                return ForgotPasswordScreen(
+                  email: arguments['email'],
+                  headerMaxExtent: 200,
+                );
+              },
+            ),
+          ],
+        ),
+        GoRoute(
+          path: 'profile',
+          builder: (context, state) {
+            return ProfileScreen(
+              providers: const [],
+              actions: [
+                SignedOutAction((context) {
+                  context.replace('/');
+                }),
+              ],
+            );
+          },
+        ),
+      ],
+    ),
+  ],
+);
+
 class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      initialRoute: '/home',
-      routes: {
-        '/home': (context) {
-          return const HomePage();
-        },
-        '/sign-in': ((context) {
-          return SignInScreen(
-            actions: [
-              ForgotPasswordAction(((context, email) {
-                Navigator.of(context)
-                    .pushNamed('/forgot-password', arguments: {'email': email});
-              })),
-              AuthStateChangeAction(((context, state) {
-                if (state is SignedIn || state is UserCreated) {
-                  var user = (state is SignedIn)
-                      ? state.user
-                      : (state as UserCreated).credential.user;
-                  if (user == null) {
-                    return;
-                  }
-                  if (state is UserCreated) {
-                    user.updateDisplayName(user.email!.split('@')[0]);
-                  }
-                  if (!user.emailVerified) {
-                    user.sendEmailVerification();
-                    const snackBar = SnackBar(
-                        content: Text(
-                            'Please check your email to verify your email address'));
-                    ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                  }
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                }
-              })),
-            ],
-          );
-        }),
-        '/forgot-password': ((context) {
-          final arguments = ModalRoute.of(context)?.settings.arguments
-              as Map<String, dynamic>?;
-
-          return ForgotPasswordScreen(
-            email: arguments?['email'] as String,
-            headerMaxExtent: 200,
-          );
-        }),
-        '/profile': ((context) {
-          return ProfileScreen(
-            providers: const [],
-            actions: [
-              SignedOutAction(
-                ((context) {
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                }),
-              ),
-            ],
-          );
-        })
-      },
+    return MaterialApp.router(
       title: 'Firebase Meetup',
       theme: ThemeData(
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
@@ -94,6 +112,7 @@ class App extends StatelessWidget {
         ),
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
+      routerConfig: _router,
     );
   }
 }

--- a/firebase-get-to-know-flutter/step_07/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_07/lib/src/authentication.dart
@@ -25,9 +25,7 @@ class AuthFunc extends StatelessWidget {
           padding: const EdgeInsets.only(left: 24, bottom: 8),
           child: StyledButton(
               onPressed: () {
-                !loggedIn
-                    ? context.push('/sign-in')
-                    : signOut();
+                !loggedIn ? context.push('/sign-in') : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
         ),

--- a/firebase-get-to-know-flutter/step_07/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_07/lib/src/authentication.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'widgets.dart';
 
@@ -25,7 +26,7 @@ class AuthFunc extends StatelessWidget {
           child: StyledButton(
               onPressed: () {
                 !loggedIn
-                    ? Navigator.of(context).pushNamed('/sign-in')
+                    ? context.push('/sign-in')
                     : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
@@ -36,7 +37,7 @@ class AuthFunc extends StatelessWidget {
               padding: const EdgeInsets.only(left: 24, bottom: 8),
               child: StyledButton(
                   onPressed: () {
-                    Navigator.of(context).pushNamed('/profile');
+                    context.push('/profile');
                   },
                   child: const Text('Profile')),
             ))

--- a/firebase-get-to-know-flutter/step_07/pubspec.yaml
+++ b/firebase-get-to-know-flutter/step_07/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   google_fonts: ^3.0.1
+  go_router: ^5.2.1
   cloud_firestore: ^4.1.0
   firebase_auth: ^4.1.4
   firebase_core: ^2.3.0

--- a/firebase-get-to-know-flutter/step_09/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_09/lib/main.dart
@@ -4,6 +4,7 @@
 
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
@@ -19,85 +20,102 @@ void main() {
   ));
 }
 
+final _router = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const HomePage(),
+      routes: [
+        GoRoute(
+          path: 'sign-in',
+          builder: (context, state) {
+            return SignInScreen(
+              actions: [
+                ForgotPasswordAction(((context, email) {
+                  final uri = Uri(
+                    path: '/sign-in/forgot-password',
+                    queryParameters: <String, String?>{
+                      'email': email,
+                    },
+                  );
+                  context.push(uri.toString());
+                })),
+                AuthStateChangeAction(((context, state) {
+                  if (state is SignedIn || state is UserCreated) {
+                    var user = (state is SignedIn)
+                        ? state.user
+                        : (state as UserCreated).credential.user;
+                    if (user == null) {
+                      return;
+                    }
+                    if (state is UserCreated) {
+                      user.updateDisplayName(user.email!.split('@')[0]);
+                    }
+                    if (!user.emailVerified) {
+                      user.sendEmailVerification();
+                      const snackBar = SnackBar(
+                          content: Text(
+                              'Please check your email to verify your email address'));
+                      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                    }
+                    context.replace('/');
+                  }
+                })),
+              ],
+            );
+          },
+          routes: [
+            GoRoute(
+              path: 'forgot-password',
+              builder: (context, state) {
+                final arguments = state.queryParams;
+                return ForgotPasswordScreen(
+                  email: arguments['email'],
+                  headerMaxExtent: 200,
+                );
+              },
+            ),
+          ],
+        ),
+        GoRoute(
+          path: 'profile',
+          builder: (context, state) {
+            return Consumer<ApplicationState>(
+              builder: (context, appState, _) => ProfileScreen(
+                key: ValueKey(appState.emailVerified),
+                providers: const [],
+                actions: [
+                  SignedOutAction(
+                    ((context) {
+                      context.replace('/');
+                    }),
+                  ),
+                ],
+                children: [
+                  Visibility(
+                      visible: !appState.emailVerified,
+                      child: OutlinedButton(
+                        child: const Text('Recheck Verification State'),
+                        onPressed: () {
+                          appState.refreshLoggedInUser();
+                        },
+                      ))
+                ],
+              ),
+            );
+          },
+        ),
+      ],
+    ),
+  ],
+);
+
 class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      initialRoute: '/home',
-      routes: {
-        '/home': (context) {
-          return const HomePage();
-        },
-        '/sign-in': ((context) {
-          return SignInScreen(
-            actions: [
-              ForgotPasswordAction(((context, email) {
-                Navigator.of(context)
-                    .pushNamed('/forgot-password', arguments: {'email': email});
-              })),
-              AuthStateChangeAction(((context, state) {
-                if (state is SignedIn || state is UserCreated) {
-                  var user = (state is SignedIn)
-                      ? state.user
-                      : (state as UserCreated).credential.user;
-                  if (user == null) {
-                    return;
-                  }
-                  if (state is UserCreated) {
-                    user.updateDisplayName(user.email!.split('@')[0]);
-                    user.sendEmailVerification();
-                  }
-                  if (!user.emailVerified) {
-                    user.sendEmailVerification();
-                    const snackBar = SnackBar(
-                        content: Text(
-                            'Please check your email to verify your email address'));
-                    ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                  }
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                }
-              })),
-            ],
-          );
-        }),
-        '/forgot-password': ((context) {
-          final arguments = ModalRoute.of(context)?.settings.arguments
-              as Map<String, dynamic>?;
-
-          return ForgotPasswordScreen(
-            email: arguments?['email'] as String,
-            headerMaxExtent: 200,
-          );
-        }),
-        '/profile': ((context) {
-          return Consumer<ApplicationState>(
-            builder: (context, appState, _) => ProfileScreen(
-              key: ValueKey(appState.emailVerified),
-              providers: const [],
-              actions: [
-                SignedOutAction(
-                  ((context) {
-                    Navigator.of(context)
-                        .popUntil(ModalRoute.withName('/home'));
-                  }),
-                ),
-              ],
-              children: [
-                Visibility(
-                    visible: !appState.emailVerified,
-                    child: OutlinedButton(
-                      child: const Text('Recheck Verification State'),
-                      onPressed: () {
-                        appState.refreshLoggedInUser();
-                      },
-                    ))
-              ],
-            ),
-          );
-        })
-      },
+    return MaterialApp.router(
       title: 'Firebase Meetup',
       theme: ThemeData(
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
@@ -109,6 +127,7 @@ class App extends StatelessWidget {
         ),
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
+      routerConfig: _router,
     );
   }
 }

--- a/firebase-get-to-know-flutter/step_09/lib/src/authentication.dart
+++ b/firebase-get-to-know-flutter/step_09/lib/src/authentication.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'widgets.dart';
 
@@ -26,9 +27,7 @@ class AuthFunc extends StatelessWidget {
           padding: const EdgeInsets.only(left: 24, bottom: 8),
           child: StyledButton(
               onPressed: () {
-                !loggedIn
-                    ? Navigator.of(context).pushNamed('/sign-in')
-                    : signOut();
+                !loggedIn ? context.push('/sign-in') : signOut();
               },
               child: !loggedIn ? const Text('RSVP') : const Text('Logout')),
         ),
@@ -38,7 +37,7 @@ class AuthFunc extends StatelessWidget {
               padding: const EdgeInsets.only(left: 24, bottom: 8),
               child: StyledButton(
                   onPressed: () {
-                    Navigator.of(context).pushNamed('/profile');
+                    context.push('/profile');
                   },
                   child: const Text('Profile')),
             )),

--- a/firebase-get-to-know-flutter/step_09/pubspec.yaml
+++ b/firebase-get-to-know-flutter/step_09/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   google_fonts: ^3.0.1
+  go_router: ^5.2.1
   cloud_firestore: ^4.1.0
   firebase_auth: ^4.1.4
   firebase_core: ^2.3.0


### PR DESCRIPTION
TODO: Rebase with main once https://github.com/flutter/codelabs/pull/1206 lands.

In this PR I continue the work on migrating the firebase-get-to-know codelab to go_router.

The work is in the commits with the title "Step xx: add go_router"

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`). <-- needs codelab update
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
