### PR TITLE
enable Material 3 on adaptive_app codelab code

### DIFF
--- a/adaptive_app/step_04/lib/main.dart
+++ b/adaptive_app/step_04/lib/main.dart
@@ -65,8 +65,14 @@ class PlaylistsApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'FlutterDev Playlists',
-      theme: FlexColorScheme.light(scheme: FlexScheme.red).toTheme,
-      darkTheme: FlexColorScheme.dark(scheme: FlexScheme.red).toTheme,
+      theme: FlexColorScheme.light(
+        scheme: FlexScheme.red,
+        useMaterial3: true,
+      ).toTheme,
+      darkTheme: FlexColorScheme.dark(
+        scheme: FlexScheme.red,
+        useMaterial3: true,
+      ).toTheme,
       themeMode: ThemeMode.dark, // Or ThemeMode.System if you'd prefer
       debugShowCheckedModeBanner: false,
       routerConfig: _router,

--- a/adaptive_app/step_05/lib/main.dart
+++ b/adaptive_app/step_05/lib/main.dart
@@ -68,8 +68,14 @@ class PlaylistsApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'FlutterDev Playlists',
-      theme: FlexColorScheme.light(scheme: FlexScheme.red).toTheme,
-      darkTheme: FlexColorScheme.dark(scheme: FlexScheme.red).toTheme,
+      theme: FlexColorScheme.light(
+        scheme: FlexScheme.red,
+        useMaterial3: true,
+      ).toTheme,
+      darkTheme: FlexColorScheme.dark(
+        scheme: FlexScheme.red,
+        useMaterial3: true,
+      ).toTheme,
       themeMode: ThemeMode.dark, // Or ThemeMode.System if you'd prefer
       debugShowCheckedModeBanner: false,
       routerConfig: _router,

--- a/adaptive_app/step_06/lib/main.dart
+++ b/adaptive_app/step_06/lib/main.dart
@@ -68,8 +68,14 @@ class PlaylistsApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'FlutterDev Playlists',
-      theme: FlexColorScheme.light(scheme: FlexScheme.red).toTheme,
-      darkTheme: FlexColorScheme.dark(scheme: FlexScheme.red).toTheme,
+      theme: FlexColorScheme.light(
+        scheme: FlexScheme.red,
+        useMaterial3: true,
+      ).toTheme,
+      darkTheme: FlexColorScheme.dark(
+        scheme: FlexScheme.red,
+        useMaterial3: true,
+      ).toTheme,
       themeMode: ThemeMode.dark, // Or ThemeMode.System if you'd prefer
       debugShowCheckedModeBanner: false,
       routerConfig: _router,

--- a/adaptive_app/step_07/lib/main.dart
+++ b/adaptive_app/step_07/lib/main.dart
@@ -82,8 +82,14 @@ class PlaylistsApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: 'Your Playlists',
-      theme: FlexColorScheme.light(scheme: FlexScheme.red).toTheme,
-      darkTheme: FlexColorScheme.dark(scheme: FlexScheme.red).toTheme,
+      theme: FlexColorScheme.light(
+        scheme: FlexScheme.red,
+        useMaterial3: true,
+      ).toTheme,
+      darkTheme: FlexColorScheme.dark(
+        scheme: FlexScheme.red,
+        useMaterial3: true,
+      ).toTheme,
       themeMode: ThemeMode.dark, // Or ThemeMode.System if you'd prefer
       debugShowCheckedModeBanner: false,
       routerConfig: _router,


### PR DESCRIPTION
Part of the work to enable Material 3 on all codelabs and samples.

Initial work done by setting `useMaterial3: true` on the ThemeData creation.

Further work needs to be done, updating the codelab code and screenshots. I already have access to the Adaptive App's Flutter codelab doc, so I can update it once this PR is approved.

### Before Material 3

![image](https://user-images.githubusercontent.com/2494376/211320264-9c6d0a3e-c0ab-4a15-ab9a-372e590b2a68.png)

![image](https://user-images.githubusercontent.com/2494376/211320360-91d285e7-0547-4c89-92c4-a555400fb70b.png)

![image](https://user-images.githubusercontent.com/2494376/211320429-5168a8d0-1c67-4b02-8883-5037497c73ca.png)

### With Material 3

![image](https://user-images.githubusercontent.com/2494376/211320594-715245f7-5925-4f50-9ad7-2c45915c82f7.png)

![image](https://user-images.githubusercontent.com/2494376/211320744-b93e2796-8039-4d8d-b043-f22c217202a1.png)

![image](https://user-images.githubusercontent.com/2494376/211320794-cee30c0f-0eda-480e-8f96-891736146717.png)


## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`). <-- pending
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
