### PR TITLE
Enable Material 3 on Cookbook codelab code

### DIFF
--- a/cookbook/lib/app.dart
+++ b/cookbook/lib/app.dart
@@ -48,6 +48,7 @@ class App extends StatelessWidget {
     final themeData = ThemeData(
       brightness: Brightness.light,
       primaryColor: Colors.blue,
+      useMaterial3: true,
     );
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,

--- a/cookbook/lib/app.dart
+++ b/cookbook/lib/app.dart
@@ -28,7 +28,7 @@ GoRouter _router(Widget? home) {
         routes: [
           for (final item in items)
             GoRoute(
-              path: item.name,
+              path: item.path,
               builder: (context, _) => item.builder(context),
             )
         ],


### PR DESCRIPTION
Enabled Material 3 on the `cookbook` codelab code.

Also found a navigation bug while running it, which has been fixed as well.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
