### PR TITLE
Fixing mislabelled file in step 5 of "Get to know Firebase for Flutter"

### DIFF
--- a/firebase-get-to-know-flutter/steps/index.lab.md
+++ b/firebase-get-to-know-flutter/steps/index.lab.md
@@ -468,7 +468,7 @@ Each screen has a different type of action associated with it based on the new s
 
 3. In the `HomePage` class's build method, integrate the app state with the `AuthFunc` widget:
 
-####  [lib/main.dart](https://github.com/flutter/codelabs/blob/master/firebase-get-to-know-flutter/step_05/lib/main.dart#L54)
+####  [lib/home_page.dart](https://github.com/flutter/codelabs/blob/master/firebase-get-to-know-flutter/step_05/lib/home_page.dart#L9)
 
 ```dart
 class HomePage extends StatelessWidget {

--- a/firebase-get-to-know-flutter/steps/index.lab.md
+++ b/firebase-get-to-know-flutter/steps/index.lab.md
@@ -468,7 +468,7 @@ Each screen has a different type of action associated with it based on the new s
 
 3. In the `HomePage` class's build method, integrate the app state with the `AuthFunc` widget:
 
-####  [lib/home_page.dart](https://github.com/flutter/codelabs/blob/master/firebase-get-to-know-flutter/step_05/lib/home_page.dart#L9)
+####  [lib/home_page.dart](https://github.com/flutter/codelabs/blob/master/firebase-get-to-know-flutter/step_05/lib/home_page.dart#L14)
 
 ```dart
 class HomePage extends StatelessWidget {


### PR DESCRIPTION
In Step 5 of the code lab, `main.dart` is referenced by name, despite the step requiring a change to `home_page.dart` instead. I found this a bit confusing when I was looking for the `HomePage` method in `main.dart`, so I think it makes sense to correct this as proposed.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.