### PR TITLE
Enable Material 3 on Google Maps Codelab

### DIFF
--- a/google-maps-in-flutter/step_4/lib/main.dart
+++ b/google-maps-in-flutter/step_4/lib/main.dart
@@ -38,10 +38,14 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: Colors.green[700],
+      ),
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Maps Sample App'),
-          backgroundColor: Colors.green[700],
+          elevation: 2,
         ),
         body: GoogleMap(
           onMapCreated: _onMapCreated,

--- a/google-maps-in-flutter/step_5/lib/main.dart
+++ b/google-maps-in-flutter/step_5/lib/main.dart
@@ -52,10 +52,14 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: Colors.green[700],
+      ),
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Google Office Locations'),
-          backgroundColor: Colors.green[700],
+          elevation: 2,
         ),
         body: GoogleMap(
           onMapCreated: _onMapCreated,


### PR DESCRIPTION
Enabled Material 3 on the Google Maps codelab.

### Before Material 3

<img width="510" alt="Screenshot 2023-01-11 at 16 24 35" src="https://user-images.githubusercontent.com/2494376/211847197-45e8e361-c8ea-4dc9-a23d-588b1d06d2c7.png">

<img width="488" alt="Screenshot 2023-01-11 at 16 28 47" src="https://user-images.githubusercontent.com/2494376/211847250-554baa67-b87a-45d1-8701-b7bb2e4452db.png">

### With Material 3

<img width="488" alt="Screenshot 2023-01-11 at 16 23 44" src="https://user-images.githubusercontent.com/2494376/211847306-4f291058-e8c8-4b63-a1b9-8218a7552c6b.png">

<img width="510" alt="Screenshot 2023-01-11 at 16 27 50" src="https://user-images.githubusercontent.com/2494376/211847337-a2126acb-3cb7-427f-bd90-146315f0b5ce.png">

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`). <-- codelab needs update
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
