### PR TITLE
Enable Material 3 on star_counter

### DIFF
--- a/star_counter/step_04/lib/main.dart
+++ b/star_counter/step_04/lib/main.dart
@@ -16,6 +16,7 @@ class StarCounterApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         brightness: Brightness.light,
+        useMaterial3: true,
       ),
       routes: {
         '/': (context) => const HomePage(),

--- a/star_counter/step_05/lib/main.dart
+++ b/star_counter/step_05/lib/main.dart
@@ -17,6 +17,7 @@ class StarCounterApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         brightness: Brightness.light,
+        useMaterial3: true,
       ),
       routes: {
         '/': (context) => const HomePage(),

--- a/star_counter/step_06/lib/main.dart
+++ b/star_counter/step_06/lib/main.dart
@@ -17,6 +17,7 @@ class StarCounterApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         brightness: Brightness.light,
+        useMaterial3: true,
       ),
       routes: {
         '/': (context) => const HomePage(),

--- a/star_counter/step_07/lib/main.dart
+++ b/star_counter/step_07/lib/main.dart
@@ -14,6 +14,7 @@ class StarCounterApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         brightness: Brightness.light,
+        useMaterial3: true,
       ),
       routes: {
         '/': (context) => const HomePage(),

--- a/star_counter/step_08/lib/main.dart
+++ b/star_counter/step_08/lib/main.dart
@@ -14,6 +14,7 @@ class StarCounterApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         brightness: Brightness.light,
+        useMaterial3: true,
       ),
       routes: {
         '/': (context) => const HomePage(),

--- a/star_counter/step_09/lib/main.dart
+++ b/star_counter/step_09/lib/main.dart
@@ -13,6 +13,7 @@ class StarCounterApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         brightness: Brightness.light,
+        useMaterial3: true,
       ),
       routes: {
         '/': (context) => const HomePage(),

--- a/star_counter/step_10/lib/main.dart
+++ b/star_counter/step_10/lib/main.dart
@@ -14,6 +14,7 @@ class StarCounterApp extends StatelessWidget {
     return MaterialApp(
       theme: ThemeData(
         brightness: Brightness.light,
+        useMaterial3: true,
       ),
       routes: {
         '/': (context) => const HomePage(),


### PR DESCRIPTION
Enabled Material 3 on the star_counter codelab.

#### Before Material 3

<img width="1312" alt="Screenshot 2023-01-17 at 15 47 40" src="https://user-images.githubusercontent.com/2494376/212931003-c9db4fd4-b01b-49f2-9226-0994d2a1e339.png">

#### With Material 3

<img width="1312" alt="Screenshot 2023-01-17 at 15 47 26" src="https://user-images.githubusercontent.com/2494376/212931070-44422448-a09a-4a06-97e0-e0014f918ce6.png">


Codelab code and screenshots need update, e.g. in https://codelabs.developers.google.com/codelabs/web-url-launcher#3 where the main.dart is created.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`). 
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
