### PR TITLE
Migrate testing_codelab to Material 3

### DIFF
--- a/testing_codelab/step_04/lib/main.dart
+++ b/testing_codelab/step_04/lib/main.dart
@@ -23,6 +23,7 @@ class TestingApp extends StatelessWidget {
         title: 'Testing Sample',
         theme: ThemeData(
           primarySwatch: Colors.blue,
+          useMaterial3: true,
         ),
         routes: {
           HomePage.routeName: (context) => const HomePage(),

--- a/testing_codelab/step_04/lib/screens/home.dart
+++ b/testing_codelab/step_04/lib/screens/home.dart
@@ -19,7 +19,6 @@ class HomePage extends StatelessWidget {
         title: const Text('Testing Sample'),
         actions: <Widget>[
           TextButton.icon(
-            style: TextButton.styleFrom(foregroundColor: Colors.white),
             onPressed: () {
               Navigator.pushNamed(context, FavoritesPage.routeName);
             },

--- a/testing_codelab/step_05/lib/main.dart
+++ b/testing_codelab/step_05/lib/main.dart
@@ -23,6 +23,7 @@ class TestingApp extends StatelessWidget {
         title: 'Testing Sample',
         theme: ThemeData(
           primarySwatch: Colors.blue,
+          useMaterial3: true,
         ),
         routes: {
           HomePage.routeName: (context) => const HomePage(),

--- a/testing_codelab/step_05/lib/screens/home.dart
+++ b/testing_codelab/step_05/lib/screens/home.dart
@@ -19,7 +19,6 @@ class HomePage extends StatelessWidget {
         title: const Text('Testing Sample'),
         actions: <Widget>[
           TextButton.icon(
-            style: TextButton.styleFrom(foregroundColor: Colors.white),
             onPressed: () {
               Navigator.pushNamed(context, FavoritesPage.routeName);
             },

--- a/testing_codelab/step_06/lib/main.dart
+++ b/testing_codelab/step_06/lib/main.dart
@@ -23,6 +23,7 @@ class TestingApp extends StatelessWidget {
         title: 'Testing Sample',
         theme: ThemeData(
           primarySwatch: Colors.blue,
+          useMaterial3: true,
         ),
         routes: {
           HomePage.routeName: (context) => const HomePage(),

--- a/testing_codelab/step_06/lib/screens/home.dart
+++ b/testing_codelab/step_06/lib/screens/home.dart
@@ -19,7 +19,6 @@ class HomePage extends StatelessWidget {
         title: const Text('Testing Sample'),
         actions: <Widget>[
           TextButton.icon(
-            style: TextButton.styleFrom(foregroundColor: Colors.white),
             onPressed: () {
               Navigator.pushNamed(context, FavoritesPage.routeName);
             },

--- a/testing_codelab/step_07/lib/main.dart
+++ b/testing_codelab/step_07/lib/main.dart
@@ -23,6 +23,7 @@ class TestingApp extends StatelessWidget {
         title: 'Testing Sample',
         theme: ThemeData(
           primarySwatch: Colors.blue,
+          useMaterial3: true,
         ),
         routes: {
           HomePage.routeName: (context) => const HomePage(),

--- a/testing_codelab/step_07/lib/screens/home.dart
+++ b/testing_codelab/step_07/lib/screens/home.dart
@@ -19,7 +19,6 @@ class HomePage extends StatelessWidget {
         title: const Text('Testing Sample'),
         actions: <Widget>[
           TextButton.icon(
-            style: TextButton.styleFrom(foregroundColor: Colors.white),
             onPressed: () {
               Navigator.pushNamed(context, FavoritesPage.routeName);
             },


### PR DESCRIPTION
Migrated testing-codelab to Material 3.

Removed the custom style (color white) from the App bar button and used the default one.

Codelab would need to be updated as well.

### Before Material 3

<img width="912" alt="Screenshot 2023-01-18 at 15 46 34" src="https://user-images.githubusercontent.com/2494376/213203844-c2d2de9f-2d7e-43d7-b95e-c0e3c6dbec99.png">

<img width="912" alt="Screenshot 2023-01-18 at 15 48 45" src="https://user-images.githubusercontent.com/2494376/213203872-7636c086-5c6d-4b99-b599-2a05dc08928d.png">

### With Material 3

<img width="912" alt="Screenshot 2023-01-18 at 15 47 48" src="https://user-images.githubusercontent.com/2494376/213204032-d5eaf0b2-a8bb-4c3c-b0a1-383f12e6836b.png">

<img width="912" alt="Screenshot 2023-01-18 at 15 48 14" src="https://user-images.githubusercontent.com/2494376/213204071-621847c0-ae3e-41a8-9137-391c012821a3.png">

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
