### PR TITLE
Migrate webview_flutter to Material 3

### DIFF
--- a/webview_flutter/step_04/lib/main.dart
+++ b/webview_flutter/step_04/lib/main.dart
@@ -7,8 +7,9 @@ import 'package:webview_flutter/webview_flutter.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }

--- a/webview_flutter/step_05/lib/main.dart
+++ b/webview_flutter/step_05/lib/main.dart
@@ -8,8 +8,9 @@ import 'src/web_view_stack.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }

--- a/webview_flutter/step_06/lib/main.dart
+++ b/webview_flutter/step_06/lib/main.dart
@@ -10,8 +10,9 @@ import 'src/web_view_stack.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }

--- a/webview_flutter/step_07/lib/main.dart
+++ b/webview_flutter/step_07/lib/main.dart
@@ -10,8 +10,9 @@ import 'src/web_view_stack.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }

--- a/webview_flutter/step_08/lib/main.dart
+++ b/webview_flutter/step_08/lib/main.dart
@@ -11,8 +11,9 @@ import 'src/web_view_stack.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }

--- a/webview_flutter/step_09/lib/main.dart
+++ b/webview_flutter/step_09/lib/main.dart
@@ -11,8 +11,9 @@ import 'src/web_view_stack.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }

--- a/webview_flutter/step_10/lib/main.dart
+++ b/webview_flutter/step_10/lib/main.dart
@@ -11,8 +11,9 @@ import 'src/web_view_stack.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }

--- a/webview_flutter/step_11/lib/main.dart
+++ b/webview_flutter/step_11/lib/main.dart
@@ -11,8 +11,9 @@ import 'src/web_view_stack.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }

--- a/webview_flutter/step_12/lib/main.dart
+++ b/webview_flutter/step_12/lib/main.dart
@@ -11,8 +11,9 @@ import 'src/web_view_stack.dart';
 
 void main() {
   runApp(
-    const MaterialApp(
-      home: WebViewApp(),
+    MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: const WebViewApp(),
     ),
   );
 }


### PR DESCRIPTION
Migrate webview-flutter to Material 3.

Codelab documet could be updated as well.

#### Before Material 3

<img src="https://user-images.githubusercontent.com/2494376/213479863-ebd4ec32-447f-49e5-9f09-39680ad28d31.png" width="400px">

#### With Material 3

<img src="https://user-images.githubusercontent.com/2494376/213479898-b5a2f017-b54c-439c-a5d1-9429a6998c55.png" width="400px">

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
