### PR TITLE
Use CupertinoListTile for row item

### DIFF
--- a/cupertino_store/step_02/lib/product_list_tab.dart
+++ b/cupertino_store/step_02/lib/product_list_tab.dart
@@ -34,22 +34,18 @@ class ProductListTab extends StatelessWidget {
             ),
             SliverSafeArea(
               top: false,
-              minimum: const EdgeInsets.only(top: 8),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    if (index < products.length) {
-                      return ProductRowItem(
-                        product: products[index],
-                        lastItem: index == products.length - 1,
-                      );
-                    }
-
-                    return null;
-                  },
+              minimum: const EdgeInsets.only(top: 0),
+              sliver: SliverToBoxAdapter(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in products) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-              ),
-            )
+              )
+            ),
           ],
         );
       },

--- a/cupertino_store/step_02/lib/product_list_tab.dart
+++ b/cupertino_store/step_02/lib/product_list_tab.dart
@@ -33,19 +33,19 @@ class ProductListTab extends StatelessWidget {
               largeTitle: Text('Cupertino Store'),
             ),
             SliverSafeArea(
-              top: false,
-              minimum: const EdgeInsets.only(top: 0),
-              sliver: SliverToBoxAdapter(
-                child: CupertinoListSection(
-                  topMargin: 0,
-                  children: 
-                    [for(var product in products) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
-                ),
-              )
-            ),
+                top: false,
+                minimum: const EdgeInsets.only(top: 0),
+                sliver: SliverToBoxAdapter(
+                  child: CupertinoListSection(
+                    topMargin: 0,
+                    children: [
+                      for (var product in products)
+                        ProductRowItem(
+                          product: product,
+                        )
+                    ],
+                  ),
+                )),
           ],
         );
       },

--- a/cupertino_store/step_02/lib/product_row_item.dart
+++ b/cupertino_store/step_02/lib/product_row_item.dart
@@ -22,16 +22,14 @@ import 'styles.dart';
 class ProductRowItem extends StatelessWidget {
   const ProductRowItem({
     required this.product,
-    required this.lastItem,
     super.key,
   });
 
   final Product product;
-  final bool lastItem;
 
   @override
   Widget build(BuildContext context) {
-    final row = SafeArea(
+    return SafeArea(
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
@@ -72,26 +70,6 @@ class ProductRowItem extends StatelessWidget {
           ),
         ),
       )
-    );
-
-    if (lastItem) {
-      return row;
-    }
-
-    return Column(
-      children: <Widget>[
-        row,
-        Padding(
-          padding: const EdgeInsets.only(
-            left: 100,
-            right: 16,
-          ),
-          child: Container(
-            height: 1,
-            color: Styles.productRowDivider,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/cupertino_store/step_02/lib/product_row_item.dart
+++ b/cupertino_store/step_02/lib/product_row_item.dart
@@ -30,46 +30,45 @@ class ProductRowItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      top: false,
-      bottom: false,
-      minimum: const EdgeInsets.only(
-        left: 0,
-        top: 8,
-        bottom: 8,
-        right: 8,
-      ),
-      child: CupertinoListTile(
-        leading: ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: Image.asset(
-            product.assetName,
-            package: product.assetPackage,
-            fit: BoxFit.cover,
-            width: 68,
-            height: 68,
+        top: false,
+        bottom: false,
+        minimum: const EdgeInsets.only(
+          left: 0,
+          top: 8,
+          bottom: 8,
+          right: 8,
+        ),
+        child: CupertinoListTile(
+          leading: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: Image.asset(
+              product.assetName,
+              package: product.assetPackage,
+              fit: BoxFit.cover,
+              width: 68,
+              height: 68,
+            ),
           ),
-        ),
-        leadingSize: 68,
-        title: Text(
-          product.name,
-          style: Styles.productRowItemName,
-        ),
-        subtitle: Text(
-          '\$${product.price}',
-          style: Styles.productRowItemPrice,
-        ),
-        trailing: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: () {
-            final model = Provider.of<AppStateModel>(context, listen: false);
-            model.addProductToCart(product.id);
-          },
-          child: const Icon(
-            CupertinoIcons.plus_circled,
-            semanticLabel: 'Add',
+          leadingSize: 68,
+          title: Text(
+            product.name,
+            style: Styles.productRowItemName,
           ),
-        ),
-      )
-    );
+          subtitle: Text(
+            '\$${product.price}',
+            style: Styles.productRowItemPrice,
+          ),
+          trailing: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: () {
+              final model = Provider.of<AppStateModel>(context, listen: false);
+              model.addProductToCart(product.id);
+            },
+            child: const Icon(
+              CupertinoIcons.plus_circled,
+              semanticLabel: 'Add',
+            ),
+          ),
+        ));
   }
 }

--- a/cupertino_store/step_02/lib/product_row_item.dart
+++ b/cupertino_store/step_02/lib/product_row_item.dart
@@ -35,56 +35,43 @@ class ProductRowItem extends StatelessWidget {
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
-        left: 16,
+        left: 0,
         top: 8,
         bottom: 8,
         right: 8,
       ),
-      child: Row(
-        children: <Widget>[
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: Image.asset(
-              product.assetName,
-              package: product.assetPackage,
-              fit: BoxFit.cover,
-              width: 76,
-              height: 76,
-            ),
+      child: CupertinoListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Image.asset(
+            product.assetName,
+            package: product.assetPackage,
+            fit: BoxFit.cover,
+            width: 68,
+            height: 68,
           ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    product.name,
-                    style: Styles.productRowItemName,
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 8)),
-                  Text(
-                    '\$${product.price}',
-                    style: Styles.productRowItemPrice,
-                  )
-                ],
-              ),
-            ),
+        ),
+        leadingSize: 68,
+        title: Text(
+          product.name,
+          style: Styles.productRowItemName,
+        ),
+        subtitle: Text(
+          '\$${product.price}',
+          style: Styles.productRowItemPrice,
+        ),
+        trailing: CupertinoButton(
+          padding: EdgeInsets.zero,
+          onPressed: () {
+            final model = Provider.of<AppStateModel>(context, listen: false);
+            model.addProductToCart(product.id);
+          },
+          child: const Icon(
+            CupertinoIcons.plus_circled,
+            semanticLabel: 'Add',
           ),
-          CupertinoButton(
-            padding: EdgeInsets.zero,
-            onPressed: () {
-              final model = Provider.of<AppStateModel>(context, listen: false);
-              model.addProductToCart(product.id);
-            },
-            child: const Icon(
-              CupertinoIcons.plus_circled,
-              semanticLabel: 'Add',
-            ),
-          ),
-        ],
-      ),
+        ),
+      )
     );
 
     if (lastItem) {

--- a/cupertino_store/step_03/lib/product_list_tab.dart
+++ b/cupertino_store/step_03/lib/product_list_tab.dart
@@ -34,22 +34,18 @@ class ProductListTab extends StatelessWidget {
             ),
             SliverSafeArea(
               top: false,
-              minimum: const EdgeInsets.only(top: 8),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    if (index < products.length) {
-                      return ProductRowItem(
-                        product: products[index],
-                        lastItem: index == products.length - 1,
-                      );
-                    }
-
-                    return null;
-                  },
+              minimum: const EdgeInsets.only(top: 0),
+              sliver: SliverToBoxAdapter(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in products) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-              ),
-            )
+              )
+            ),
           ],
         );
       },

--- a/cupertino_store/step_03/lib/product_list_tab.dart
+++ b/cupertino_store/step_03/lib/product_list_tab.dart
@@ -33,19 +33,19 @@ class ProductListTab extends StatelessWidget {
               largeTitle: Text('Cupertino Store'),
             ),
             SliverSafeArea(
-              top: false,
-              minimum: const EdgeInsets.only(top: 0),
-              sliver: SliverToBoxAdapter(
-                child: CupertinoListSection(
-                  topMargin: 0,
-                  children: 
-                    [for(var product in products) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
-                ),
-              )
-            ),
+                top: false,
+                minimum: const EdgeInsets.only(top: 0),
+                sliver: SliverToBoxAdapter(
+                  child: CupertinoListSection(
+                    topMargin: 0,
+                    children: [
+                      for (var product in products)
+                        ProductRowItem(
+                          product: product,
+                        )
+                    ],
+                  ),
+                )),
           ],
         );
       },

--- a/cupertino_store/step_03/lib/product_row_item.dart
+++ b/cupertino_store/step_03/lib/product_row_item.dart
@@ -22,16 +22,14 @@ import 'styles.dart';
 class ProductRowItem extends StatelessWidget {
   const ProductRowItem({
     required this.product,
-    required this.lastItem,
     super.key,
   });
 
   final Product product;
-  final bool lastItem;
 
   @override
   Widget build(BuildContext context) {
-    final row = SafeArea(
+    return SafeArea(
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
@@ -72,26 +70,6 @@ class ProductRowItem extends StatelessWidget {
           ),
         ),
       )
-    );
-
-    if (lastItem) {
-      return row;
-    }
-
-    return Column(
-      children: <Widget>[
-        row,
-        Padding(
-          padding: const EdgeInsets.only(
-            left: 100,
-            right: 16,
-          ),
-          child: Container(
-            height: 1,
-            color: Styles.productRowDivider,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/cupertino_store/step_03/lib/product_row_item.dart
+++ b/cupertino_store/step_03/lib/product_row_item.dart
@@ -30,46 +30,45 @@ class ProductRowItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      top: false,
-      bottom: false,
-      minimum: const EdgeInsets.only(
-        left: 0,
-        top: 8,
-        bottom: 8,
-        right: 8,
-      ),
-      child: CupertinoListTile(
-        leading: ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: Image.asset(
-            product.assetName,
-            package: product.assetPackage,
-            fit: BoxFit.cover,
-            width: 68,
-            height: 68,
+        top: false,
+        bottom: false,
+        minimum: const EdgeInsets.only(
+          left: 0,
+          top: 8,
+          bottom: 8,
+          right: 8,
+        ),
+        child: CupertinoListTile(
+          leading: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: Image.asset(
+              product.assetName,
+              package: product.assetPackage,
+              fit: BoxFit.cover,
+              width: 68,
+              height: 68,
+            ),
           ),
-        ),
-        leadingSize: 68,
-        title: Text(
-          product.name,
-          style: Styles.productRowItemName,
-        ),
-        subtitle: Text(
-          '\$${product.price}',
-          style: Styles.productRowItemPrice,
-        ),
-        trailing: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: () {
-            final model = Provider.of<AppStateModel>(context, listen: false);
-            model.addProductToCart(product.id);
-          },
-          child: const Icon(
-            CupertinoIcons.plus_circled,
-            semanticLabel: 'Add',
+          leadingSize: 68,
+          title: Text(
+            product.name,
+            style: Styles.productRowItemName,
           ),
-        ),
-      )
-    );
+          subtitle: Text(
+            '\$${product.price}',
+            style: Styles.productRowItemPrice,
+          ),
+          trailing: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: () {
+              final model = Provider.of<AppStateModel>(context, listen: false);
+              model.addProductToCart(product.id);
+            },
+            child: const Icon(
+              CupertinoIcons.plus_circled,
+              semanticLabel: 'Add',
+            ),
+          ),
+        ));
   }
 }

--- a/cupertino_store/step_03/lib/product_row_item.dart
+++ b/cupertino_store/step_03/lib/product_row_item.dart
@@ -35,56 +35,43 @@ class ProductRowItem extends StatelessWidget {
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
-        left: 16,
+        left: 0,
         top: 8,
         bottom: 8,
         right: 8,
       ),
-      child: Row(
-        children: <Widget>[
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: Image.asset(
-              product.assetName,
-              package: product.assetPackage,
-              fit: BoxFit.cover,
-              width: 76,
-              height: 76,
-            ),
+      child: CupertinoListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Image.asset(
+            product.assetName,
+            package: product.assetPackage,
+            fit: BoxFit.cover,
+            width: 68,
+            height: 68,
           ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    product.name,
-                    style: Styles.productRowItemName,
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 8)),
-                  Text(
-                    '\$${product.price}',
-                    style: Styles.productRowItemPrice,
-                  )
-                ],
-              ),
-            ),
+        ),
+        leadingSize: 68,
+        title: Text(
+          product.name,
+          style: Styles.productRowItemName,
+        ),
+        subtitle: Text(
+          '\$${product.price}',
+          style: Styles.productRowItemPrice,
+        ),
+        trailing: CupertinoButton(
+          padding: EdgeInsets.zero,
+          onPressed: () {
+            final model = Provider.of<AppStateModel>(context, listen: false);
+            model.addProductToCart(product.id);
+          },
+          child: const Icon(
+            CupertinoIcons.plus_circled,
+            semanticLabel: 'Add',
           ),
-          CupertinoButton(
-            padding: EdgeInsets.zero,
-            onPressed: () {
-              final model = Provider.of<AppStateModel>(context, listen: false);
-              model.addProductToCart(product.id);
-            },
-            child: const Icon(
-              CupertinoIcons.plus_circled,
-              semanticLabel: 'Add',
-            ),
-          ),
-        ],
-      ),
+        ),
+      )
     );
 
     if (lastItem) {

--- a/cupertino_store/step_03/lib/search_tab.dart
+++ b/cupertino_store/step_03/lib/search_tab.dart
@@ -81,11 +81,12 @@ class _SearchTabState extends State<SearchTab> {
               child: SingleChildScrollView(
                 child: CupertinoListSection(
                   topMargin: 0,
-                  children: 
-                    [for(var product in results) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
+                  children: [
+                    for (var product in results)
+                      ProductRowItem(
+                        product: product,
+                      )
+                  ],
                 ),
               ),
             ),

--- a/cupertino_store/step_03/lib/search_tab.dart
+++ b/cupertino_store/step_03/lib/search_tab.dart
@@ -78,12 +78,15 @@ class _SearchTabState extends State<SearchTab> {
           children: [
             _buildSearchBox(),
             Expanded(
-              child: ListView.builder(
-                itemBuilder: (context, index) => ProductRowItem(
-                  product: results[index],
-                  lastItem: index == results.length - 1,
+              child: SingleChildScrollView(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in results) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-                itemCount: results.length,
               ),
             ),
           ],

--- a/cupertino_store/step_04/lib/product_list_tab.dart
+++ b/cupertino_store/step_04/lib/product_list_tab.dart
@@ -34,22 +34,18 @@ class ProductListTab extends StatelessWidget {
             ),
             SliverSafeArea(
               top: false,
-              minimum: const EdgeInsets.only(top: 8),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    if (index < products.length) {
-                      return ProductRowItem(
-                        product: products[index],
-                        lastItem: index == products.length - 1,
-                      );
-                    }
-
-                    return null;
-                  },
+              minimum: const EdgeInsets.only(top: 0),
+              sliver: SliverToBoxAdapter(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in products) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-              ),
-            )
+              )
+            ),
           ],
         );
       },

--- a/cupertino_store/step_04/lib/product_list_tab.dart
+++ b/cupertino_store/step_04/lib/product_list_tab.dart
@@ -33,19 +33,19 @@ class ProductListTab extends StatelessWidget {
               largeTitle: Text('Cupertino Store'),
             ),
             SliverSafeArea(
-              top: false,
-              minimum: const EdgeInsets.only(top: 0),
-              sliver: SliverToBoxAdapter(
-                child: CupertinoListSection(
-                  topMargin: 0,
-                  children: 
-                    [for(var product in products) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
-                ),
-              )
-            ),
+                top: false,
+                minimum: const EdgeInsets.only(top: 0),
+                sliver: SliverToBoxAdapter(
+                  child: CupertinoListSection(
+                    topMargin: 0,
+                    children: [
+                      for (var product in products)
+                        ProductRowItem(
+                          product: product,
+                        )
+                    ],
+                  ),
+                )),
           ],
         );
       },

--- a/cupertino_store/step_04/lib/product_row_item.dart
+++ b/cupertino_store/step_04/lib/product_row_item.dart
@@ -22,16 +22,14 @@ import 'styles.dart';
 class ProductRowItem extends StatelessWidget {
   const ProductRowItem({
     required this.product,
-    required this.lastItem,
     super.key,
   });
 
   final Product product;
-  final bool lastItem;
 
   @override
   Widget build(BuildContext context) {
-    final row = SafeArea(
+    return SafeArea(
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
@@ -72,26 +70,6 @@ class ProductRowItem extends StatelessWidget {
           ),
         ),
       )
-    );
-
-    if (lastItem) {
-      return row;
-    }
-
-    return Column(
-      children: <Widget>[
-        row,
-        Padding(
-          padding: const EdgeInsets.only(
-            left: 100,
-            right: 16,
-          ),
-          child: Container(
-            height: 1,
-            color: Styles.productRowDivider,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/cupertino_store/step_04/lib/product_row_item.dart
+++ b/cupertino_store/step_04/lib/product_row_item.dart
@@ -30,46 +30,45 @@ class ProductRowItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      top: false,
-      bottom: false,
-      minimum: const EdgeInsets.only(
-        left: 0,
-        top: 8,
-        bottom: 8,
-        right: 8,
-      ),
-      child: CupertinoListTile(
-        leading: ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: Image.asset(
-            product.assetName,
-            package: product.assetPackage,
-            fit: BoxFit.cover,
-            width: 68,
-            height: 68,
+        top: false,
+        bottom: false,
+        minimum: const EdgeInsets.only(
+          left: 0,
+          top: 8,
+          bottom: 8,
+          right: 8,
+        ),
+        child: CupertinoListTile(
+          leading: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: Image.asset(
+              product.assetName,
+              package: product.assetPackage,
+              fit: BoxFit.cover,
+              width: 68,
+              height: 68,
+            ),
           ),
-        ),
-        leadingSize: 68,
-        title: Text(
-          product.name,
-          style: Styles.productRowItemName,
-        ),
-        subtitle: Text(
-          '\$${product.price}',
-          style: Styles.productRowItemPrice,
-        ),
-        trailing: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: () {
-            final model = Provider.of<AppStateModel>(context, listen: false);
-            model.addProductToCart(product.id);
-          },
-          child: const Icon(
-            CupertinoIcons.plus_circled,
-            semanticLabel: 'Add',
+          leadingSize: 68,
+          title: Text(
+            product.name,
+            style: Styles.productRowItemName,
           ),
-        ),
-      )
-    );
+          subtitle: Text(
+            '\$${product.price}',
+            style: Styles.productRowItemPrice,
+          ),
+          trailing: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: () {
+              final model = Provider.of<AppStateModel>(context, listen: false);
+              model.addProductToCart(product.id);
+            },
+            child: const Icon(
+              CupertinoIcons.plus_circled,
+              semanticLabel: 'Add',
+            ),
+          ),
+        ));
   }
 }

--- a/cupertino_store/step_04/lib/product_row_item.dart
+++ b/cupertino_store/step_04/lib/product_row_item.dart
@@ -35,56 +35,43 @@ class ProductRowItem extends StatelessWidget {
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
-        left: 16,
+        left: 0,
         top: 8,
         bottom: 8,
         right: 8,
       ),
-      child: Row(
-        children: <Widget>[
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: Image.asset(
-              product.assetName,
-              package: product.assetPackage,
-              fit: BoxFit.cover,
-              width: 76,
-              height: 76,
-            ),
+      child: CupertinoListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Image.asset(
+            product.assetName,
+            package: product.assetPackage,
+            fit: BoxFit.cover,
+            width: 68,
+            height: 68,
           ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    product.name,
-                    style: Styles.productRowItemName,
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 8)),
-                  Text(
-                    '\$${product.price}',
-                    style: Styles.productRowItemPrice,
-                  )
-                ],
-              ),
-            ),
+        ),
+        leadingSize: 68,
+        title: Text(
+          product.name,
+          style: Styles.productRowItemName,
+        ),
+        subtitle: Text(
+          '\$${product.price}',
+          style: Styles.productRowItemPrice,
+        ),
+        trailing: CupertinoButton(
+          padding: EdgeInsets.zero,
+          onPressed: () {
+            final model = Provider.of<AppStateModel>(context, listen: false);
+            model.addProductToCart(product.id);
+          },
+          child: const Icon(
+            CupertinoIcons.plus_circled,
+            semanticLabel: 'Add',
           ),
-          CupertinoButton(
-            padding: EdgeInsets.zero,
-            onPressed: () {
-              final model = Provider.of<AppStateModel>(context, listen: false);
-              model.addProductToCart(product.id);
-            },
-            child: const Icon(
-              CupertinoIcons.plus_circled,
-              semanticLabel: 'Add',
-            ),
-          ),
-        ],
-      ),
+        ),
+      )
     );
 
     if (lastItem) {

--- a/cupertino_store/step_04/lib/search_tab.dart
+++ b/cupertino_store/step_04/lib/search_tab.dart
@@ -81,11 +81,12 @@ class _SearchTabState extends State<SearchTab> {
               child: SingleChildScrollView(
                 child: CupertinoListSection(
                   topMargin: 0,
-                  children: 
-                    [for(var product in results) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
+                  children: [
+                    for (var product in results)
+                      ProductRowItem(
+                        product: product,
+                      )
+                  ],
                 ),
               ),
             ),

--- a/cupertino_store/step_04/lib/search_tab.dart
+++ b/cupertino_store/step_04/lib/search_tab.dart
@@ -78,12 +78,15 @@ class _SearchTabState extends State<SearchTab> {
           children: [
             _buildSearchBox(),
             Expanded(
-              child: ListView.builder(
-                itemBuilder: (context, index) => ProductRowItem(
-                  product: results[index],
-                  lastItem: index == results.length - 1,
+              child: SingleChildScrollView(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in results) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-                itemCount: results.length,
               ),
             ),
           ],

--- a/cupertino_store/step_05/lib/product_list_tab.dart
+++ b/cupertino_store/step_05/lib/product_list_tab.dart
@@ -34,22 +34,18 @@ class ProductListTab extends StatelessWidget {
             ),
             SliverSafeArea(
               top: false,
-              minimum: const EdgeInsets.only(top: 8),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    if (index < products.length) {
-                      return ProductRowItem(
-                        product: products[index],
-                        lastItem: index == products.length - 1,
-                      );
-                    }
-
-                    return null;
-                  },
+              minimum: const EdgeInsets.only(top: 0),
+              sliver: SliverToBoxAdapter(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in products) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-              ),
-            )
+              )
+            ),
           ],
         );
       },

--- a/cupertino_store/step_05/lib/product_list_tab.dart
+++ b/cupertino_store/step_05/lib/product_list_tab.dart
@@ -33,19 +33,19 @@ class ProductListTab extends StatelessWidget {
               largeTitle: Text('Cupertino Store'),
             ),
             SliverSafeArea(
-              top: false,
-              minimum: const EdgeInsets.only(top: 0),
-              sliver: SliverToBoxAdapter(
-                child: CupertinoListSection(
-                  topMargin: 0,
-                  children: 
-                    [for(var product in products) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
-                ),
-              )
-            ),
+                top: false,
+                minimum: const EdgeInsets.only(top: 0),
+                sliver: SliverToBoxAdapter(
+                  child: CupertinoListSection(
+                    topMargin: 0,
+                    children: [
+                      for (var product in products)
+                        ProductRowItem(
+                          product: product,
+                        )
+                    ],
+                  ),
+                )),
           ],
         );
       },

--- a/cupertino_store/step_05/lib/product_row_item.dart
+++ b/cupertino_store/step_05/lib/product_row_item.dart
@@ -22,16 +22,14 @@ import 'styles.dart';
 class ProductRowItem extends StatelessWidget {
   const ProductRowItem({
     required this.product,
-    required this.lastItem,
     super.key,
   });
 
   final Product product;
-  final bool lastItem;
 
   @override
   Widget build(BuildContext context) {
-    final row = SafeArea(
+    return SafeArea(
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
@@ -72,26 +70,6 @@ class ProductRowItem extends StatelessWidget {
           ),
         ),
       )
-    );
-
-    if (lastItem) {
-      return row;
-    }
-
-    return Column(
-      children: <Widget>[
-        row,
-        Padding(
-          padding: const EdgeInsets.only(
-            left: 100,
-            right: 16,
-          ),
-          child: Container(
-            height: 1,
-            color: Styles.productRowDivider,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/cupertino_store/step_05/lib/product_row_item.dart
+++ b/cupertino_store/step_05/lib/product_row_item.dart
@@ -30,46 +30,45 @@ class ProductRowItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      top: false,
-      bottom: false,
-      minimum: const EdgeInsets.only(
-        left: 0,
-        top: 8,
-        bottom: 8,
-        right: 8,
-      ),
-      child: CupertinoListTile(
-        leading: ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: Image.asset(
-            product.assetName,
-            package: product.assetPackage,
-            fit: BoxFit.cover,
-            width: 68,
-            height: 68,
+        top: false,
+        bottom: false,
+        minimum: const EdgeInsets.only(
+          left: 0,
+          top: 8,
+          bottom: 8,
+          right: 8,
+        ),
+        child: CupertinoListTile(
+          leading: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: Image.asset(
+              product.assetName,
+              package: product.assetPackage,
+              fit: BoxFit.cover,
+              width: 68,
+              height: 68,
+            ),
           ),
-        ),
-        leadingSize: 68,
-        title: Text(
-          product.name,
-          style: Styles.productRowItemName,
-        ),
-        subtitle: Text(
-          '\$${product.price}',
-          style: Styles.productRowItemPrice,
-        ),
-        trailing: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: () {
-            final model = Provider.of<AppStateModel>(context, listen: false);
-            model.addProductToCart(product.id);
-          },
-          child: const Icon(
-            CupertinoIcons.plus_circled,
-            semanticLabel: 'Add',
+          leadingSize: 68,
+          title: Text(
+            product.name,
+            style: Styles.productRowItemName,
           ),
-        ),
-      )
-    );
+          subtitle: Text(
+            '\$${product.price}',
+            style: Styles.productRowItemPrice,
+          ),
+          trailing: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: () {
+              final model = Provider.of<AppStateModel>(context, listen: false);
+              model.addProductToCart(product.id);
+            },
+            child: const Icon(
+              CupertinoIcons.plus_circled,
+              semanticLabel: 'Add',
+            ),
+          ),
+        ));
   }
 }

--- a/cupertino_store/step_05/lib/product_row_item.dart
+++ b/cupertino_store/step_05/lib/product_row_item.dart
@@ -35,56 +35,43 @@ class ProductRowItem extends StatelessWidget {
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
-        left: 16,
+        left: 0,
         top: 8,
         bottom: 8,
         right: 8,
       ),
-      child: Row(
-        children: <Widget>[
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: Image.asset(
-              product.assetName,
-              package: product.assetPackage,
-              fit: BoxFit.cover,
-              width: 76,
-              height: 76,
-            ),
+      child: CupertinoListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Image.asset(
+            product.assetName,
+            package: product.assetPackage,
+            fit: BoxFit.cover,
+            width: 68,
+            height: 68,
           ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    product.name,
-                    style: Styles.productRowItemName,
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 8)),
-                  Text(
-                    '\$${product.price}',
-                    style: Styles.productRowItemPrice,
-                  )
-                ],
-              ),
-            ),
+        ),
+        leadingSize: 68,
+        title: Text(
+          product.name,
+          style: Styles.productRowItemName,
+        ),
+        subtitle: Text(
+          '\$${product.price}',
+          style: Styles.productRowItemPrice,
+        ),
+        trailing: CupertinoButton(
+          padding: EdgeInsets.zero,
+          onPressed: () {
+            final model = Provider.of<AppStateModel>(context, listen: false);
+            model.addProductToCart(product.id);
+          },
+          child: const Icon(
+            CupertinoIcons.plus_circled,
+            semanticLabel: 'Add',
           ),
-          CupertinoButton(
-            padding: EdgeInsets.zero,
-            onPressed: () {
-              final model = Provider.of<AppStateModel>(context, listen: false);
-              model.addProductToCart(product.id);
-            },
-            child: const Icon(
-              CupertinoIcons.plus_circled,
-              semanticLabel: 'Add',
-            ),
-          ),
-        ],
-      ),
+        ),
+      )
     );
 
     if (lastItem) {

--- a/cupertino_store/step_05/lib/search_tab.dart
+++ b/cupertino_store/step_05/lib/search_tab.dart
@@ -81,11 +81,12 @@ class _SearchTabState extends State<SearchTab> {
               child: SingleChildScrollView(
                 child: CupertinoListSection(
                   topMargin: 0,
-                  children: 
-                    [for(var product in results) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
+                  children: [
+                    for (var product in results)
+                      ProductRowItem(
+                        product: product,
+                      )
+                  ],
                 ),
               ),
             ),

--- a/cupertino_store/step_05/lib/search_tab.dart
+++ b/cupertino_store/step_05/lib/search_tab.dart
@@ -78,12 +78,15 @@ class _SearchTabState extends State<SearchTab> {
           children: [
             _buildSearchBox(),
             Expanded(
-              child: ListView.builder(
-                itemBuilder: (context, index) => ProductRowItem(
-                  product: results[index],
-                  lastItem: index == results.length - 1,
+              child: SingleChildScrollView(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in results) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-                itemCount: results.length,
               ),
             ),
           ],

--- a/cupertino_store/step_06/lib/product_list_tab.dart
+++ b/cupertino_store/step_06/lib/product_list_tab.dart
@@ -34,22 +34,18 @@ class ProductListTab extends StatelessWidget {
             ),
             SliverSafeArea(
               top: false,
-              minimum: const EdgeInsets.only(top: 8),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    if (index < products.length) {
-                      return ProductRowItem(
-                        product: products[index],
-                        lastItem: index == products.length - 1,
-                      );
-                    }
-
-                    return null;
-                  },
+              minimum: const EdgeInsets.only(top: 0),
+              sliver: SliverToBoxAdapter(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in products) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-              ),
-            )
+              )
+            ),
           ],
         );
       },

--- a/cupertino_store/step_06/lib/product_list_tab.dart
+++ b/cupertino_store/step_06/lib/product_list_tab.dart
@@ -33,19 +33,19 @@ class ProductListTab extends StatelessWidget {
               largeTitle: Text('Cupertino Store'),
             ),
             SliverSafeArea(
-              top: false,
-              minimum: const EdgeInsets.only(top: 0),
-              sliver: SliverToBoxAdapter(
-                child: CupertinoListSection(
-                  topMargin: 0,
-                  children: 
-                    [for(var product in products) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
-                ),
-              )
-            ),
+                top: false,
+                minimum: const EdgeInsets.only(top: 0),
+                sliver: SliverToBoxAdapter(
+                  child: CupertinoListSection(
+                    topMargin: 0,
+                    children: [
+                      for (var product in products)
+                        ProductRowItem(
+                          product: product,
+                        )
+                    ],
+                  ),
+                )),
           ],
         );
       },

--- a/cupertino_store/step_06/lib/product_row_item.dart
+++ b/cupertino_store/step_06/lib/product_row_item.dart
@@ -22,16 +22,14 @@ import 'styles.dart';
 class ProductRowItem extends StatelessWidget {
   const ProductRowItem({
     required this.product,
-    required this.lastItem,
     super.key,
   });
 
   final Product product;
-  final bool lastItem;
 
   @override
   Widget build(BuildContext context) {
-    final row = SafeArea(
+    return SafeArea(
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
@@ -72,26 +70,6 @@ class ProductRowItem extends StatelessWidget {
           ),
         ),
       )
-    );
-
-    if (lastItem) {
-      return row;
-    }
-
-    return Column(
-      children: <Widget>[
-        row,
-        Padding(
-          padding: const EdgeInsets.only(
-            left: 100,
-            right: 16,
-          ),
-          child: Container(
-            height: 1,
-            color: Styles.productRowDivider,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/cupertino_store/step_06/lib/product_row_item.dart
+++ b/cupertino_store/step_06/lib/product_row_item.dart
@@ -30,46 +30,45 @@ class ProductRowItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      top: false,
-      bottom: false,
-      minimum: const EdgeInsets.only(
-        left: 0,
-        top: 8,
-        bottom: 8,
-        right: 8,
-      ),
-      child: CupertinoListTile(
-        leading: ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: Image.asset(
-            product.assetName,
-            package: product.assetPackage,
-            fit: BoxFit.cover,
-            width: 68,
-            height: 68,
+        top: false,
+        bottom: false,
+        minimum: const EdgeInsets.only(
+          left: 0,
+          top: 8,
+          bottom: 8,
+          right: 8,
+        ),
+        child: CupertinoListTile(
+          leading: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: Image.asset(
+              product.assetName,
+              package: product.assetPackage,
+              fit: BoxFit.cover,
+              width: 68,
+              height: 68,
+            ),
           ),
-        ),
-        leadingSize: 68,
-        title: Text(
-          product.name,
-          style: Styles.productRowItemName,
-        ),
-        subtitle: Text(
-          '\$${product.price}',
-          style: Styles.productRowItemPrice,
-        ),
-        trailing: CupertinoButton(
-          padding: EdgeInsets.zero,
-          onPressed: () {
-            final model = Provider.of<AppStateModel>(context, listen: false);
-            model.addProductToCart(product.id);
-          },
-          child: const Icon(
-            CupertinoIcons.plus_circled,
-            semanticLabel: 'Add',
+          leadingSize: 68,
+          title: Text(
+            product.name,
+            style: Styles.productRowItemName,
           ),
-        ),
-      )
-    );
+          subtitle: Text(
+            '\$${product.price}',
+            style: Styles.productRowItemPrice,
+          ),
+          trailing: CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: () {
+              final model = Provider.of<AppStateModel>(context, listen: false);
+              model.addProductToCart(product.id);
+            },
+            child: const Icon(
+              CupertinoIcons.plus_circled,
+              semanticLabel: 'Add',
+            ),
+          ),
+        ));
   }
 }

--- a/cupertino_store/step_06/lib/product_row_item.dart
+++ b/cupertino_store/step_06/lib/product_row_item.dart
@@ -35,56 +35,43 @@ class ProductRowItem extends StatelessWidget {
       top: false,
       bottom: false,
       minimum: const EdgeInsets.only(
-        left: 16,
+        left: 0,
         top: 8,
         bottom: 8,
         right: 8,
       ),
-      child: Row(
-        children: <Widget>[
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: Image.asset(
-              product.assetName,
-              package: product.assetPackage,
-              fit: BoxFit.cover,
-              width: 76,
-              height: 76,
-            ),
+      child: CupertinoListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Image.asset(
+            product.assetName,
+            package: product.assetPackage,
+            fit: BoxFit.cover,
+            width: 68,
+            height: 68,
           ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    product.name,
-                    style: Styles.productRowItemName,
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 8)),
-                  Text(
-                    '\$${product.price}',
-                    style: Styles.productRowItemPrice,
-                  )
-                ],
-              ),
-            ),
+        ),
+        leadingSize: 68,
+        title: Text(
+          product.name,
+          style: Styles.productRowItemName,
+        ),
+        subtitle: Text(
+          '\$${product.price}',
+          style: Styles.productRowItemPrice,
+        ),
+        trailing: CupertinoButton(
+          padding: EdgeInsets.zero,
+          onPressed: () {
+            final model = Provider.of<AppStateModel>(context, listen: false);
+            model.addProductToCart(product.id);
+          },
+          child: const Icon(
+            CupertinoIcons.plus_circled,
+            semanticLabel: 'Add',
           ),
-          CupertinoButton(
-            padding: EdgeInsets.zero,
-            onPressed: () {
-              final model = Provider.of<AppStateModel>(context, listen: false);
-              model.addProductToCart(product.id);
-            },
-            child: const Icon(
-              CupertinoIcons.plus_circled,
-              semanticLabel: 'Add',
-            ),
-          ),
-        ],
-      ),
+        ),
+      )
     );
 
     if (lastItem) {

--- a/cupertino_store/step_06/lib/search_tab.dart
+++ b/cupertino_store/step_06/lib/search_tab.dart
@@ -81,11 +81,12 @@ class _SearchTabState extends State<SearchTab> {
               child: SingleChildScrollView(
                 child: CupertinoListSection(
                   topMargin: 0,
-                  children: 
-                    [for(var product in results) ProductRowItem(
-                      product: product,
-                    )]
-                  ,
+                  children: [
+                    for (var product in results)
+                      ProductRowItem(
+                        product: product,
+                      )
+                  ],
                 ),
               ),
             ),

--- a/cupertino_store/step_06/lib/search_tab.dart
+++ b/cupertino_store/step_06/lib/search_tab.dart
@@ -78,12 +78,15 @@ class _SearchTabState extends State<SearchTab> {
           children: [
             _buildSearchBox(),
             Expanded(
-              child: ListView.builder(
-                itemBuilder: (context, index) => ProductRowItem(
-                  product: results[index],
-                  lastItem: index == results.length - 1,
+              child: SingleChildScrollView(
+                child: CupertinoListSection(
+                  topMargin: 0,
+                  children: 
+                    [for(var product in results) ProductRowItem(
+                      product: product,
+                    )]
+                  ,
                 ),
-                itemCount: results.length,
               ),
             ),
           ],

--- a/cupertino_store/step_06/lib/shopping_cart_tab.dart
+++ b/cupertino_store/step_06/lib/shopping_cart_tab.dart
@@ -272,60 +272,32 @@ class ShoppingCartItem extends StatelessWidget {
     final row = SafeArea(
       top: false,
       bottom: false,
-      child: Padding(
-        padding: const EdgeInsets.only(
-          left: 16,
-          top: 8,
-          bottom: 8,
-          right: 8,
+        child: CupertinoListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Image.asset(
+            product.assetName,
+            package: product.assetPackage,
+            fit: BoxFit.cover,
+            width: 40,
+            height: 40,
+          ),
         ),
-        child: Row(
-          children: <Widget>[
-            ClipRRect(
-              borderRadius: BorderRadius.circular(4),
-              child: Image.asset(
-                product.assetName,
-                package: product.assetPackage,
-                fit: BoxFit.cover,
-                width: 40,
-                height: 40,
-              ),
-            ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        Text(
-                          product.name,
-                          style: Styles.productRowItemName,
-                        ),
-                        Text(
-                          formatter.format(quantity * product.price),
-                          style: Styles.productRowItemName,
-                        ),
-                      ],
-                    ),
-                    const SizedBox(
-                      height: 4,
-                    ),
-                    Text(
-                      '${quantity > 1 ? '$quantity x ' : ''}'
-                      '${formatter.format(product.price)}',
-                      style: Styles.productRowItemPrice,
-                    )
-                  ],
-                ),
-              ),
-            ),
-          ],
+        leadingSize: 40,
+        title: Text(
+          product.name,
+          style: Styles.productRowItemName,
         ),
-      ),
+        subtitle: Text(
+          '${quantity > 1 ? '$quantity x ' : ''}'
+          '${formatter.format(product.price)}',
+          style: Styles.productRowItemPrice,
+        ),
+        trailing:  Text(
+          formatter.format(quantity * product.price),
+          style: Styles.productRowItemName,
+        ),
+      )
     );
 
     return row;

--- a/cupertino_store/step_06/lib/shopping_cart_tab.dart
+++ b/cupertino_store/step_06/lib/shopping_cart_tab.dart
@@ -270,35 +270,34 @@ class ShoppingCartItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final row = SafeArea(
-      top: false,
-      bottom: false,
+        top: false,
+        bottom: false,
         child: CupertinoListTile(
-        leading: ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: Image.asset(
-            product.assetName,
-            package: product.assetPackage,
-            fit: BoxFit.cover,
-            width: 40,
-            height: 40,
+          leading: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: Image.asset(
+              product.assetName,
+              package: product.assetPackage,
+              fit: BoxFit.cover,
+              width: 40,
+              height: 40,
+            ),
           ),
-        ),
-        leadingSize: 40,
-        title: Text(
-          product.name,
-          style: Styles.productRowItemName,
-        ),
-        subtitle: Text(
-          '${quantity > 1 ? '$quantity x ' : ''}'
-          '${formatter.format(product.price)}',
-          style: Styles.productRowItemPrice,
-        ),
-        trailing:  Text(
-          formatter.format(quantity * product.price),
-          style: Styles.productRowItemName,
-        ),
-      )
-    );
+          leadingSize: 40,
+          title: Text(
+            product.name,
+            style: Styles.productRowItemName,
+          ),
+          subtitle: Text(
+            '${quantity > 1 ? '$quantity x ' : ''}'
+            '${formatter.format(product.price)}',
+            style: Styles.productRowItemPrice,
+          ),
+          trailing: Text(
+            formatter.format(quantity * product.price),
+            style: Styles.productRowItemName,
+          ),
+        ));
 
     return row;
   }


### PR DESCRIPTION
Implements the new CupertinoListTile for the Cupertino Store codelab, instead of manually recreating the iOS visuals.

The result looks like this:

<img width="499" alt="Screenshot 2023-01-24 at 2 46 18 PM" src="https://user-images.githubusercontent.com/58190796/214438459-922496d5-61c5-4a13-85bd-8b0732d28ecf.png">

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
