### PR TITLE
Make an accessibility improvement

### DIFF
--- a/namer/codelab_rebuild.yaml
+++ b/namer/codelab_rebuild.yaml
@@ -448,7 +448,7 @@ steps:
           +        child: Text(
           +          pair.asLowerCase,
           +          style: style,
-          +          semanticsLabel: pair.asPascalCase,
+          +          semanticsLabel: "${pair.first} ${pair.second}",
           +        ),
                  ),
                );

--- a/namer/step_05_f_accessibility/lib/main.dart
+++ b/namer/step_05_f_accessibility/lib/main.dart
@@ -79,7 +79,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_05_g_center_vertical/lib/main.dart
+++ b/namer/step_05_g_center_vertical/lib/main.dart
@@ -80,7 +80,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_05_h_center_horizontal/lib/main.dart
+++ b/namer/step_05_h_center_horizontal/lib/main.dart
@@ -82,7 +82,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_05_i_optional_changes/lib/main.dart
+++ b/namer/step_05_i_optional_changes/lib/main.dart
@@ -82,7 +82,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_06_a_business_logic/lib/main.dart
+++ b/namer/step_06_a_business_logic/lib/main.dart
@@ -93,7 +93,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_06_b_add_row/lib/main.dart
+++ b/namer/step_06_b_add_row/lib/main.dart
@@ -98,7 +98,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_06_c_add_like_button/lib/main.dart
+++ b/namer/step_06_c_add_like_button/lib/main.dart
@@ -113,7 +113,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_07_a_split_my_home_page/lib/main.dart
+++ b/namer/step_07_a_split_my_home_page/lib/main.dart
@@ -148,7 +148,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_07_b_convert_to_stateful/lib/main.dart
+++ b/namer/step_07_b_convert_to_stateful/lib/main.dart
@@ -153,7 +153,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_07_c_add_selectedindex/lib/main.dart
+++ b/namer/step_07_c_add_selectedindex/lib/main.dart
@@ -157,7 +157,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_07_d_use_selectedindex/lib/main.dart
+++ b/namer/step_07_d_use_selectedindex/lib/main.dart
@@ -169,7 +169,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_07_e_add_layout_builder/lib/main.dart
+++ b/namer/step_07_e_add_layout_builder/lib/main.dart
@@ -171,7 +171,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );

--- a/namer/step_08/lib/main.dart
+++ b/namer/step_08/lib/main.dart
@@ -171,7 +171,7 @@ class BigCard extends StatelessWidget {
         child: Text(
           pair.asLowerCase,
           style: style,
-          semanticsLabel: pair.asPascalCase,
+          semanticsLabel: "${pair.first} ${pair.second}",
         ),
       ),
     );


### PR DESCRIPTION
According to https://github.com/flutter/flutter/issues/120132, `asPascalCase` is not enough for all screen readers to understand that a word pair is not a single word.

Going with a lot more direct approach with `"${pair.first} ${pair.second}”`.

Fixes https://github.com/flutter/flutter/issues/120132.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
