### PR TITLE
Use `dart test` on non-Flutter projects

### DIFF
--- a/flutter_ci_script_shared.sh
+++ b/flutter_ci_script_shared.sh
@@ -47,9 +47,11 @@ function ci_codelabs () {
             dart format --output none --set-exit-if-changed .
 
             # Run the actual tests.
-            if [ -d "test" ]
-            then
-                flutter test
+            if grep -q flutter: pubspec.yaml; then
+              flutter test
+            else
+              # If the project is not a Flutter project, use the Dart CLI.
+              dart test
             fi
 
             popd

--- a/flutter_ci_script_shared.sh
+++ b/flutter_ci_script_shared.sh
@@ -47,11 +47,14 @@ function ci_codelabs () {
             dart format --output none --set-exit-if-changed .
 
             # Run the actual tests.
-            if grep -q flutter: pubspec.yaml; then
-              flutter test
-            else
-              # If the project is not a Flutter project, use the Dart CLI.
-              dart test
+            if [ -d "test" ]
+            then
+                if grep -q flutter: pubspec.yaml; then
+                  flutter test
+                else
+                  # If the project is not a Flutter project, use the Dart CLI.
+                  dart test
+                fi
             fi
 
             popd

--- a/flutter_ci_script_shared.sh
+++ b/flutter_ci_script_shared.sh
@@ -49,7 +49,7 @@ function ci_codelabs () {
             # Run the actual tests.
             if [ -d "test" ]
             then
-                if grep -q flutter: pubspec.yaml; then
+                if grep -q "flutter:" "pubspec.yaml"; then
                   flutter test
                 else
                   # If the project is not a Flutter project, use the Dart CLI.


### PR DESCRIPTION
A change in `test_api` caused an incompatibility with the pinned version of `flutter_test`. I guess projects should explicitly depend on `flutter_test` or if not a Flutter project, use `dart test`.

Read https://github.com/dart-lang/test/issues/1977 for more context.

I'm not sure if checking for `flutter:` is the best way to decide which command to use, so let me know if you think there's a better way or if we should just use a list of projects to use `dart` commands on :)