### PR TITLE
'Next-Generation', `_LitImage` widget'ification, 'Into the Unknown'

### DIFF
--- a/next-gen-ui/codelab_rebuild.yaml
+++ b/next-gen-ui/codelab_rebuild.yaml
@@ -1664,7 +1664,7 @@ steps:
                 home: Scaffold(
                   body: Center(
                     child: Text(
-                      'Insert Next Generation UI Here...',
+                      'Insert Next-Generation UI Here...',
                       style: TextStyles.h2,
                     ),
                   ),
@@ -1719,8 +1719,8 @@ steps:
       - name: Patch lib/main.dart
         path: next_gen_ui/lib/main.dart
         patch-u: |
-          --- b/next-gen-ui/step_02/lib/main.dart
-          +++ a/next-gen-ui/step_02/lib/main.dart
+          --- b/next-gen-ui/step_02_a/lib/main.dart
+          +++ a/next-gen-ui/step_02_a/lib/main.dart
           @@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
            import 'package:flutter/material.dart';
            import 'package:window_size/window_size.dart';
@@ -1737,7 +1737,7 @@ steps:
           -      home: Scaffold(
           -        body: Center(
           -          child: Text(
-          -            'Insert Next Generation UI Here...',
+          -            'Insert Next-Generation UI Here...',
           -            style: TextStyles.h2,
           -          ),
           -        ),
@@ -1963,27 +1963,25 @@ steps:
         patch-u: |
           --- b/next-gen-ui/step_02_f/lib/title_screen/title_screen.dart
           +++ a/next-gen-ui/step_02_f/lib/title_screen/title_screen.dart
-          @@ -9,6 +9,9 @@ import '../assets.dart';
-           class TitleScreen extends StatelessWidget {
-             const TitleScreen({super.key});
-           
-          +  final _finalReceiveLightAmt = 0.7;
-          +  final _finalEmitLightAmt = 0.5;
-          +
-             @override
-             Widget build(BuildContext context) {
-               return Scaffold(
-          @@ -51,4 +54,19 @@ class TitleScreen extends StatelessWidget {
-                 ),
+          @@ -52,3 +52,27 @@ class TitleScreen extends StatelessWidget {
                );
              }
+           }
           +
-          +  // ignore: unused_element
-          +  Widget _buildLitImage(
-          +      {required Color color, required String imgSrc, bool emit = false}) {
+          +// ignore: unused_element
+          +class _LitImage extends StatelessWidget {
+          +  const _LitImage({
+          +    required this.color,
+          +    required this.imgSrc,
+          +    required this.lightAmt,
+          +  });
+          +  final Color color;
+          +  final String imgSrc;
+          +  final double lightAmt;
+          +
+          +  @override
+          +  Widget build(BuildContext context) {
           +    final hsl = HSLColor.fromColor(color);
-          +    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-          +
           +    return ColorFiltered(
           +      colorFilter: ColorFilter.mode(
           +        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
@@ -1992,7 +1990,7 @@ steps:
           +      child: Image.asset(imgSrc),
           +    );
           +  }
-           }
+          +}
       - name: Build Web app
         path: next_gen_ui
         flutter: build web
@@ -2015,7 +2013,7 @@ steps:
         patch-u: |
           --- b/next-gen-ui/step_02_g/lib/title_screen/title_screen.dart
           +++ a/next-gen-ui/step_02_g/lib/title_screen/title_screen.dart
-          @@ -5,6 +5,7 @@
+          @@ -5,12 +5,19 @@
            import 'package:flutter/material.dart';
            
            import '../assets.dart';
@@ -2023,8 +2021,10 @@ steps:
            
            class TitleScreen extends StatelessWidget {
              const TitleScreen({super.key});
-          @@ -14,6 +15,9 @@ class TitleScreen extends StatelessWidget {
            
+          +  final _finalReceiveLightAmt = 0.7;
+          +  final _finalEmitLightAmt = 0.5;
+          +
              @override
              Widget build(BuildContext context) {
           +    final orbColor = AppColors.orbColors[0];
@@ -2033,14 +2033,15 @@ steps:
                return Scaffold(
                  backgroundColor: Colors.black,
                  body: Center(
-          @@ -23,29 +27,49 @@ class TitleScreen extends StatelessWidget {
+          @@ -20,29 +27,53 @@ class TitleScreen extends StatelessWidget {
                        Image.asset(AssetPaths.titleBgBase),
            
                        /// Bg-Receive
           -            Image.asset(AssetPaths.titleBgReceive),
-          +            _buildLitImage(
+          +            _LitImage(
           +              color: orbColor,
           +              imgSrc: AssetPaths.titleBgReceive,
+          +              lightAmt: _finalReceiveLightAmt,
           +            ),
            
                        /// Mg + Fg
@@ -2049,24 +2050,26 @@ steps:
                            children: [
                              /// Mg-Base
           -                  Image.asset(AssetPaths.titleMgBase),
-          +                  _buildLitImage(
+          +                  _LitImage(
           +                    imgSrc: AssetPaths.titleMgBase,
           +                    color: orbColor,
+          +                    lightAmt: _finalReceiveLightAmt,
           +                  ),
            
                              /// Mg-Receive
           -                  Image.asset(AssetPaths.titleMgReceive),
-          +                  _buildLitImage(
+          +                  _LitImage(
           +                    imgSrc: AssetPaths.titleMgReceive,
           +                    color: orbColor,
+          +                    lightAmt: _finalReceiveLightAmt,
           +                  ),
            
                              /// Mg-Emit
           -                  Image.asset(AssetPaths.titleMgEmit),
-          +                  _buildLitImage(
+          +                  _LitImage(
           +                    imgSrc: AssetPaths.titleMgEmit,
-          +                    emit: true,
           +                    color: emitColor,
+          +                    lightAmt: _finalEmitLightAmt,
           +                  ),
            
                              /// Fg-Rocks
@@ -2074,29 +2077,30 @@ steps:
            
                              /// Fg-Receive
           -                  Image.asset(AssetPaths.titleFgReceive),
-          +                  _buildLitImage(
+          +                  _LitImage(
           +                    imgSrc: AssetPaths.titleFgReceive,
           +                    color: orbColor,
+          +                    lightAmt: _finalReceiveLightAmt,
           +                  ),
            
                              /// Fg-Emit
           -                  Image.asset(AssetPaths.titleFgEmit),
-          +                  _buildLitImage(
+          +                  _LitImage(
           +                    imgSrc: AssetPaths.titleFgEmit,
-          +                    emit: true,
           +                    color: emitColor,
+          +                    lightAmt: _finalEmitLightAmt,
           +                  ),
                            ],
                          ),
                        ),
-          @@ -55,7 +79,6 @@ class TitleScreen extends StatelessWidget {
-               );
+          @@ -53,7 +84,6 @@ class TitleScreen extends StatelessWidget {
              }
+           }
            
-          -  // ignore: unused_element
-             Widget _buildLitImage(
-                 {required Color color, required String imgSrc, bool emit = false}) {
-               final hsl = HSLColor.fromColor(color);
+          -// ignore: unused_element
+           class _LitImage extends StatelessWidget {
+             const _LitImage({
+               required this.color,
       - name: Build Web app
         path: next_gen_ui
         flutter: build web
@@ -2192,7 +2196,7 @@ steps:
            
            class TitleScreen extends StatelessWidget {
              const TitleScreen({super.key});
-          @@ -73,6 +74,11 @@ class TitleScreen extends StatelessWidget {
+          @@ -77,6 +78,11 @@ class TitleScreen extends StatelessWidget {
                            ],
                          ),
                        ),
@@ -2437,53 +2441,55 @@ steps:
           @@ -29,7 +50,7 @@ class TitleScreen extends StatelessWidget {
            
                        /// Bg-Receive
-                       _buildLitImage(
+                       _LitImage(
           -              color: orbColor,
           +              color: _orbColor,
                          imgSrc: AssetPaths.titleBgReceive,
+                         lightAmt: _finalReceiveLightAmt,
                        ),
-           
-          @@ -40,20 +61,20 @@ class TitleScreen extends StatelessWidget {
+          @@ -41,21 +62,21 @@ class TitleScreen extends StatelessWidget {
                              /// Mg-Base
-                             _buildLitImage(
+                             _LitImage(
                                imgSrc: AssetPaths.titleMgBase,
           -                    color: orbColor,
           +                    color: _orbColor,
+                               lightAmt: _finalReceiveLightAmt,
                              ),
            
                              /// Mg-Receive
-                             _buildLitImage(
+                             _LitImage(
                                imgSrc: AssetPaths.titleMgReceive,
           -                    color: orbColor,
           +                    color: _orbColor,
+                               lightAmt: _finalReceiveLightAmt,
                              ),
            
                              /// Mg-Emit
-                             _buildLitImage(
+                             _LitImage(
                                imgSrc: AssetPaths.titleMgEmit,
-                               emit: true,
           -                    color: emitColor,
           +                    color: _emitColor,
+                               lightAmt: _finalEmitLightAmt,
                              ),
            
-                             /// Fg-Rocks
-          @@ -62,22 +83,26 @@ class TitleScreen extends StatelessWidget {
+          @@ -65,14 +86,14 @@ class TitleScreen extends StatelessWidget {
                              /// Fg-Receive
-                             _buildLitImage(
+                             _LitImage(
                                imgSrc: AssetPaths.titleFgReceive,
           -                    color: orbColor,
           +                    color: _orbColor,
+                               lightAmt: _finalReceiveLightAmt,
                              ),
            
                              /// Fg-Emit
-                             _buildLitImage(
+                             _LitImage(
                                imgSrc: AssetPaths.titleFgEmit,
-                               emit: true,
           -                    color: emitColor,
           +                    color: _emitColor,
+                               lightAmt: _finalEmitLightAmt,
                              ),
                            ],
-                         ),
+          @@ -80,8 +101,12 @@ class TitleScreen extends StatelessWidget {
                        ),
            
                        /// UI
@@ -2616,7 +2622,7 @@ steps:
         patch-u: |
           --- b/next-gen-ui/step_03_c/lib/title_screen/title_screen.dart
           +++ a/next-gen-ui/step_03_c/lib/title_screen/title_screen.dart
-          @@ -102,6 +102,8 @@ class _TitleScreenState extends State<TitleScreen> {
+          @@ -106,6 +106,8 @@ class _TitleScreenState extends State<TitleScreen> {
                            difficulty: _difficulty,
                            onDifficultyFocused: _handleDifficultyFocused,
                            onDifficultyPressed: _handleDifficultyPressed,
@@ -2852,7 +2858,16 @@ steps:
            
            import '../assets.dart';
            import '../styles.dart';
-          @@ -126,3 +127,36 @@ class _TitleScreenState extends State<TitleScreen> {
+          @@ -111,7 +112,7 @@ class _TitleScreenState extends State<TitleScreen> {
+                         ),
+                       ),
+                     ],
+          -        ),
+          +        ).animate().fadeIn(duration: 1.seconds, delay: .3.seconds),
+                 ),
+               );
+             }
+          @@ -139,3 +140,36 @@ class _LitImage extends StatelessWidget {
                );
              }
            }
@@ -2911,7 +2926,7 @@ steps:
         patch-u: |
           --- b/next-gen-ui/step_04_f/lib/title_screen/title_screen.dart
           +++ a/next-gen-ui/step_04_f/lib/title_screen/title_screen.dart
-          @@ -44,70 +44,76 @@ class _TitleScreenState extends State<TitleScreen> {
+          @@ -44,75 +44,81 @@ class _TitleScreenState extends State<TitleScreen> {
                return Scaffold(
                  backgroundColor: Colors.black,
                  body: Center(
@@ -2921,9 +2936,10 @@ steps:
           -            Image.asset(AssetPaths.titleBgBase),
           -
           -            /// Bg-Receive
-          -            _buildLitImage(
+          -            _LitImage(
           -              color: _orbColor,
           -              imgSrc: AssetPaths.titleBgReceive,
+          -              lightAmt: _finalReceiveLightAmt,
           -            ),
           -
           -            /// Mg + Fg
@@ -2931,9 +2947,10 @@ steps:
           -              child: Stack(
           -                children: [
           -                  /// Mg-Base
-          -                  _buildLitImage(
+          -                  _LitImage(
           -                    imgSrc: AssetPaths.titleMgBase,
           -                    color: _orbColor,
+          -                    lightAmt: _finalReceiveLightAmt,
           +        child: _AnimatedColors(
           +          orbColor: _orbColor,
           +          emitColor: _emitColor,
@@ -2944,9 +2961,10 @@ steps:
           +                Image.asset(AssetPaths.titleBgBase),
           +
           +                /// Bg-Receive
-          +                _buildLitImage(
+          +                _LitImage(
           +                  color: orbColor,
           +                  imgSrc: AssetPaths.titleBgReceive,
+          +                  lightAmt: _finalReceiveLightAmt,
           +                ),
           +
           +                /// Mg + Fg
@@ -2954,53 +2972,57 @@ steps:
           +                  child: Stack(
           +                    children: [
           +                      /// Mg-Base
-          +                      _buildLitImage(
+          +                      _LitImage(
           +                        imgSrc: AssetPaths.titleMgBase,
           +                        color: orbColor,
+          +                        lightAmt: _finalReceiveLightAmt,
           +                      ),
           +
           +                      /// Mg-Receive
-          +                      _buildLitImage(
+          +                      _LitImage(
           +                        imgSrc: AssetPaths.titleMgReceive,
           +                        color: orbColor,
+          +                        lightAmt: _finalReceiveLightAmt,
           +                      ),
           +
           +                      /// Mg-Emit
-          +                      _buildLitImage(
+          +                      _LitImage(
           +                        imgSrc: AssetPaths.titleMgEmit,
-          +                        emit: true,
           +                        color: emitColor,
+          +                        lightAmt: _finalEmitLightAmt,
           +                      ),
           +
           +                      /// Fg-Rocks
           +                      Image.asset(AssetPaths.titleFgBase),
           +
           +                      /// Fg-Receive
-          +                      _buildLitImage(
+          +                      _LitImage(
           +                        imgSrc: AssetPaths.titleFgReceive,
           +                        color: orbColor,
+          +                        lightAmt: _finalReceiveLightAmt,
           +                      ),
           +
           +                      /// Fg-Emit
-          +                      _buildLitImage(
+          +                      _LitImage(
           +                        imgSrc: AssetPaths.titleFgEmit,
-          +                        emit: true,
           +                        color: emitColor,
+          +                        lightAmt: _finalEmitLightAmt,
           +                      ),
           +                    ],
                              ),
           -
           -                  /// Mg-Receive
-          -                  _buildLitImage(
+          -                  _LitImage(
           -                    imgSrc: AssetPaths.titleMgReceive,
           -                    color: _orbColor,
+          -                    lightAmt: _finalReceiveLightAmt,
           -                  ),
           -
           -                  /// Mg-Emit
-          -                  _buildLitImage(
+          -                  _LitImage(
           -                    imgSrc: AssetPaths.titleMgEmit,
-          -                    emit: true,
           -                    color: _emitColor,
+          -                    lightAmt: _finalEmitLightAmt,
           +                ),
           +
           +                /// UI
@@ -3017,16 +3039,17 @@ steps:
           -                  Image.asset(AssetPaths.titleFgBase),
           -
           -                  /// Fg-Receive
-          -                  _buildLitImage(
+          -                  _LitImage(
           -                    imgSrc: AssetPaths.titleFgReceive,
           -                    color: _orbColor,
+          -                    lightAmt: _finalReceiveLightAmt,
           -                  ),
           -
           -                  /// Fg-Emit
-          -                  _buildLitImage(
+          -                  _LitImage(
           -                    imgSrc: AssetPaths.titleFgEmit,
-          -                    emit: true,
           -                    color: _emitColor,
+          -                    lightAmt: _finalEmitLightAmt,
           -                  ),
           -                ],
           -              ),
@@ -3043,14 +3066,16 @@ steps:
           -              ),
           -            ),
           -          ],
+          -        ).animate().fadeIn(duration: 1.seconds, delay: .3.seconds),
           +                ),
           +              ],
-          +            );
+          +            ).animate().fadeIn(duration: 1.seconds, delay: .3.seconds);
           +          },
-                   ),
+          +        ),
                  ),
                );
-          @@ -128,7 +134,6 @@ class _TitleScreenState extends State<TitleScreen> {
+             }
+          @@ -141,7 +147,6 @@ class _LitImage extends StatelessWidget {
              }
            }
            
@@ -3224,7 +3249,7 @@ steps:
              Color get _emitColor =>
                  AppColors.emitColors[_difficultyOverride ?? _difficulty];
              Color get _orbColor =>
-          @@ -27,93 +48,183 @@ class _TitleScreenState extends State<TitleScreen> {
+          @@ -27,97 +48,193 @@ class _TitleScreenState extends State<TitleScreen> {
            
              /// Currently focused difficulty (if any)
              int? _difficultyOverride;
@@ -3325,9 +3350,10 @@ steps:
           -                Image.asset(AssetPaths.titleBgBase),
           -
           -                /// Bg-Receive
-          -                _buildLitImage(
+          -                _LitImage(
           -                  color: orbColor,
           -                  imgSrc: AssetPaths.titleBgReceive,
+          -                  lightAmt: _finalReceiveLightAmt,
           -                ),
           -
           -                /// Mg + Fg
@@ -3335,38 +3361,41 @@ steps:
           -                  child: Stack(
           -                    children: [
           -                      /// Mg-Base
-          -                      _buildLitImage(
+          -                      _LitImage(
           -                        imgSrc: AssetPaths.titleMgBase,
           -                        color: orbColor,
+          -                        lightAmt: _finalReceiveLightAmt,
           -                      ),
           -
           -                      /// Mg-Receive
-          -                      _buildLitImage(
+          -                      _LitImage(
           -                        imgSrc: AssetPaths.titleMgReceive,
           -                        color: orbColor,
+          -                        lightAmt: _finalReceiveLightAmt,
           -                      ),
           -
           -                      /// Mg-Emit
-          -                      _buildLitImage(
+          -                      _LitImage(
           -                        imgSrc: AssetPaths.titleMgEmit,
-          -                        emit: true,
           -                        color: emitColor,
+          -                        lightAmt: _finalEmitLightAmt,
           -                      ),
           -
           -                      /// Fg-Rocks
           -                      Image.asset(AssetPaths.titleFgBase),
           -
           -                      /// Fg-Receive
-          -                      _buildLitImage(
+          -                      _LitImage(
           -                        imgSrc: AssetPaths.titleFgReceive,
           -                        color: orbColor,
+          -                        lightAmt: _finalReceiveLightAmt,
           -                      ),
           -
           -                      /// Fg-Emit
-          -                      _buildLitImage(
+          -                      _LitImage(
           -                        imgSrc: AssetPaths.titleFgEmit,
-          -                        emit: true,
           -                        color: emitColor,
+          -                        lightAmt: _finalEmitLightAmt,
           -                      ),
           -                    ],
           +        child: MouseRegion(
@@ -3381,9 +3410,11 @@ steps:
           +                  Image.asset(AssetPaths.titleBgBase),
           +
           +                  /// Bg-Receive
-          +                  _buildLitImage(
+          +                  _LitImage(
           +                    color: orbColor,
           +                    imgSrc: AssetPaths.titleBgReceive,
+          +                    pulseEffect: _pulseEffect,
+          +                    lightAmt: _finalReceiveLightAmt,
                              ),
           -                ),
           -
@@ -3417,7 +3448,7 @@ steps:
                              ),
           -                ),
           -              ],
-          -            );
+          -            ).animate().fadeIn(duration: 1.seconds, delay: .3.seconds);
           -          },
           +
           +                  /// Mg + Fg
@@ -3425,38 +3456,46 @@ steps:
           +                    child: Stack(
           +                      children: [
           +                        /// Mg-Base
-          +                        _buildLitImage(
+          +                        _LitImage(
           +                          imgSrc: AssetPaths.titleMgBase,
           +                          color: orbColor,
+          +                          pulseEffect: _pulseEffect,
+          +                          lightAmt: _finalReceiveLightAmt,
           +                        ),
           +
           +                        /// Mg-Receive
-          +                        _buildLitImage(
+          +                        _LitImage(
           +                          imgSrc: AssetPaths.titleMgReceive,
           +                          color: orbColor,
+          +                          pulseEffect: _pulseEffect,
+          +                          lightAmt: _finalReceiveLightAmt,
           +                        ),
           +
           +                        /// Mg-Emit
-          +                        _buildLitImage(
+          +                        _LitImage(
           +                          imgSrc: AssetPaths.titleMgEmit,
-          +                          emit: true,
           +                          color: emitColor,
+          +                          pulseEffect: _pulseEffect,
+          +                          lightAmt: _finalEmitLightAmt,
           +                        ),
           +
           +                        /// Fg-Rocks
           +                        Image.asset(AssetPaths.titleFgBase),
           +
           +                        /// Fg-Receive
-          +                        _buildLitImage(
+          +                        _LitImage(
           +                          imgSrc: AssetPaths.titleFgReceive,
           +                          color: orbColor,
+          +                          pulseEffect: _pulseEffect,
+          +                          lightAmt: _finalReceiveLightAmt,
           +                        ),
           +
           +                        /// Fg-Emit
-          +                        _buildLitImage(
+          +                        _LitImage(
           +                          imgSrc: AssetPaths.titleFgEmit,
-          +                          emit: true,
           +                          color: emitColor,
+          +                          pulseEffect: _pulseEffect,
+          +                          lightAmt: _finalEmitLightAmt,
           +                        ),
           +                      ],
           +                    ),
@@ -3479,22 +3518,30 @@ steps:
                    ),
                  ),
                );
-          @@ -122,14 +233,19 @@ class _TitleScreenState extends State<TitleScreen> {
-             Widget _buildLitImage(
-                 {required Color color, required String imgSrc, bool emit = false}) {
+          @@ -128,21 +245,29 @@ class _LitImage extends StatelessWidget {
+             const _LitImage({
+               required this.color,
+               required this.imgSrc,
+          +    required this.pulseEffect,
+               required this.lightAmt,
+             });
+             final Color color;
+             final String imgSrc;
+          +  final AnimationController pulseEffect;
+             final double lightAmt;
+           
+             @override
+             Widget build(BuildContext context) {
                final hsl = HSLColor.fromColor(color);
-          -    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-          -
           -    return ColorFiltered(
           -      colorFilter: ColorFilter.mode(
           -        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
           -        BlendMode.modulate,
           -      ),
           +    return ListenableBuilder(
-          +      listenable: _pulseEffect,
+          +      listenable: pulseEffect,
                  child: Image.asset(imgSrc),
           +      builder: (context, child) {
-          +        final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
           +        return ColorFiltered(
           +          colorFilter: ColorFilter.mode(
           +            hsl.withLightness(hsl.lightness * lightAmt).toColor(),
@@ -3606,8 +3653,8 @@ steps:
            import 'title_screen_ui.dart';
            
            class TitleScreen extends StatefulWidget {
-          @@ -192,6 +193,19 @@ class _TitleScreenState extends State<TitleScreen>
-                                     color: emitColor,
+          @@ -199,6 +200,19 @@ class _TitleScreenState extends State<TitleScreen>
+                                     lightAmt: _finalEmitLightAmt,
                                    ),
            
           +                        /// Particle Field

--- a/next-gen-ui/codelab_rebuild.yaml
+++ b/next-gen-ui/codelab_rebuild.yaml
@@ -2178,7 +2178,7 @@ steps:
                       Image.asset(AssetPaths.titleSelectedRight, height: 65),
                     ],
                   ),
-                  Text('THE LAST STAND', style: TextStyles.h3),
+                  Text('INTO THE UNKNOWN', style: TextStyles.h3),
                 ],
               );
             }
@@ -2686,9 +2686,9 @@ steps:
                        Image.asset(AssetPaths.titleSelectedRight, height: 65),
                      ],
           -        ),
-          -        Text('THE LAST STAND', style: TextStyles.h3),
+          -        Text('INTO THE UNKNOWN', style: TextStyles.h3),
           +        ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-          +        Text('THE LAST STAND', style: TextStyles.h3)
+          +        Text('INTO THE UNKNOWN', style: TextStyles.h3)
           +            .animate()
           +            .fadeIn(delay: 1.seconds, duration: .7.seconds),
                  ],

--- a/next-gen-ui/step_01/lib/main.dart
+++ b/next-gen-ui/step_01/lib/main.dart
@@ -29,7 +29,7 @@ class NextGenApp extends StatelessWidget {
       home: Scaffold(
         body: Center(
           child: Text(
-            'Insert Next Generation UI Here...',
+            'Insert Next-Generation UI Here...',
             style: TextStyles.h2,
           ),
         ),

--- a/next-gen-ui/step_02_f/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_02_f/lib/title_screen/title_screen.dart
@@ -9,9 +9,6 @@ import '../assets.dart';
 class TitleScreen extends StatelessWidget {
   const TitleScreen({super.key});
 
-  final _finalReceiveLightAmt = 0.7;
-  final _finalEmitLightAmt = 0.5;
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -54,13 +51,22 @@ class TitleScreen extends StatelessWidget {
       ),
     );
   }
+}
 
-  // ignore: unused_element
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+// ignore: unused_element
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_02_g/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_02_g/lib/title_screen/title_screen.dart
@@ -27,9 +27,10 @@ class TitleScreen extends StatelessWidget {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -37,38 +38,41 @@ class TitleScreen extends StatelessWidget {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -78,12 +82,21 @@ class TitleScreen extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_03_a/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_03_a/lib/title_screen/title_screen.dart
@@ -28,9 +28,10 @@ class TitleScreen extends StatelessWidget {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -38,38 +39,41 @@ class TitleScreen extends StatelessWidget {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -84,12 +88,21 @@ class TitleScreen extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_03_a/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_03_a/lib/title_screen/title_screen_ui.dart
@@ -55,7 +55,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ),
-        Text('THE LAST STAND', style: TextStyles.h3),
+        Text('INTO THE UNKNOWN', style: TextStyles.h3),
       ],
     );
   }

--- a/next-gen-ui/step_03_b/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_03_b/lib/title_screen/title_screen.dart
@@ -49,9 +49,10 @@ class _TitleScreenState extends State<TitleScreen> {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: _orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -59,38 +60,41 @@ class _TitleScreenState extends State<TitleScreen> {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -109,12 +113,21 @@ class _TitleScreenState extends State<TitleScreen> {
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_03_b/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_03_b/lib/title_screen/title_screen_ui.dart
@@ -76,7 +76,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ),
-        Text('THE LAST STAND', style: TextStyles.h3),
+        Text('INTO THE UNKNOWN', style: TextStyles.h3),
       ],
     );
   }

--- a/next-gen-ui/step_03_c/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_03_c/lib/title_screen/title_screen.dart
@@ -49,9 +49,10 @@ class _TitleScreenState extends State<TitleScreen> {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: _orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -59,38 +60,41 @@ class _TitleScreenState extends State<TitleScreen> {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -111,12 +115,21 @@ class _TitleScreenState extends State<TitleScreen> {
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_03_c/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_03_c/lib/title_screen/title_screen_ui.dart
@@ -91,7 +91,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ),
-        Text('THE LAST STAND', style: TextStyles.h3),
+        Text('INTO THE UNKNOWN', style: TextStyles.h3),
       ],
     );
   }

--- a/next-gen-ui/step_04_a/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_a/lib/title_screen/title_screen.dart
@@ -49,9 +49,10 @@ class _TitleScreenState extends State<TitleScreen> {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: _orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -59,38 +60,41 @@ class _TitleScreenState extends State<TitleScreen> {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -111,12 +115,21 @@ class _TitleScreenState extends State<TitleScreen> {
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_04_a/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_04_a/lib/title_screen/title_screen_ui.dart
@@ -92,7 +92,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],

--- a/next-gen-ui/step_04_b/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_b/lib/title_screen/title_screen.dart
@@ -49,9 +49,10 @@ class _TitleScreenState extends State<TitleScreen> {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: _orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -59,38 +60,41 @@ class _TitleScreenState extends State<TitleScreen> {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -111,12 +115,21 @@ class _TitleScreenState extends State<TitleScreen> {
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_04_b/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_04_b/lib/title_screen/title_screen_ui.dart
@@ -92,7 +92,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],

--- a/next-gen-ui/step_04_c/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_c/lib/title_screen/title_screen.dart
@@ -49,9 +49,10 @@ class _TitleScreenState extends State<TitleScreen> {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: _orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -59,38 +60,41 @@ class _TitleScreenState extends State<TitleScreen> {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -111,12 +115,21 @@ class _TitleScreenState extends State<TitleScreen> {
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_04_c/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_04_c/lib/title_screen/title_screen_ui.dart
@@ -92,7 +92,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],

--- a/next-gen-ui/step_04_d/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_d/lib/title_screen/title_screen.dart
@@ -49,9 +49,10 @@ class _TitleScreenState extends State<TitleScreen> {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: _orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -59,38 +60,41 @@ class _TitleScreenState extends State<TitleScreen> {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -111,12 +115,21 @@ class _TitleScreenState extends State<TitleScreen> {
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_04_d/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_04_d/lib/title_screen/title_screen_ui.dart
@@ -92,7 +92,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],

--- a/next-gen-ui/step_04_e/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_e/lib/title_screen/title_screen.dart
@@ -50,9 +50,10 @@ class _TitleScreenState extends State<TitleScreen> {
             Image.asset(AssetPaths.titleBgBase),
 
             /// Bg-Receive
-            _buildLitImage(
+            _LitImage(
               color: _orbColor,
               imgSrc: AssetPaths.titleBgReceive,
+              lightAmt: _finalReceiveLightAmt,
             ),
 
             /// Mg + Fg
@@ -60,38 +61,41 @@ class _TitleScreenState extends State<TitleScreen> {
               child: Stack(
                 children: [
                   /// Mg-Base
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgBase,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Mg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleMgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
 
                   /// Fg-Rocks
                   Image.asset(AssetPaths.titleFgBase),
 
                   /// Fg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgReceive,
                     color: _orbColor,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Fg-Emit
-                  _buildLitImage(
+                  _LitImage(
                     imgSrc: AssetPaths.titleFgEmit,
-                    emit: true,
                     color: _emitColor,
+                    lightAmt: _finalEmitLightAmt,
                   ),
                 ],
               ),
@@ -108,16 +112,25 @@ class _TitleScreenState extends State<TitleScreen> {
               ),
             ),
           ],
-        ),
+        ).animate().fadeIn(duration: 1.seconds, delay: .3.seconds),
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_04_e/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_04_e/lib/title_screen/title_screen_ui.dart
@@ -92,7 +92,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],

--- a/next-gen-ui/step_04_f/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_f/lib/title_screen/title_screen.dart
@@ -54,9 +54,10 @@ class _TitleScreenState extends State<TitleScreen> {
                 Image.asset(AssetPaths.titleBgBase),
 
                 /// Bg-Receive
-                _buildLitImage(
+                _LitImage(
                   color: orbColor,
                   imgSrc: AssetPaths.titleBgReceive,
+                  lightAmt: _finalReceiveLightAmt,
                 ),
 
                 /// Mg + Fg
@@ -64,38 +65,41 @@ class _TitleScreenState extends State<TitleScreen> {
                   child: Stack(
                     children: [
                       /// Mg-Base
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleMgBase,
                         color: orbColor,
+                        lightAmt: _finalReceiveLightAmt,
                       ),
 
                       /// Mg-Receive
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleMgReceive,
                         color: orbColor,
+                        lightAmt: _finalReceiveLightAmt,
                       ),
 
                       /// Mg-Emit
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleMgEmit,
-                        emit: true,
                         color: emitColor,
+                        lightAmt: _finalEmitLightAmt,
                       ),
 
                       /// Fg-Rocks
                       Image.asset(AssetPaths.titleFgBase),
 
                       /// Fg-Receive
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleFgReceive,
                         color: orbColor,
+                        lightAmt: _finalReceiveLightAmt,
                       ),
 
                       /// Fg-Emit
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleFgEmit,
-                        emit: true,
                         color: emitColor,
+                        lightAmt: _finalEmitLightAmt,
                       ),
                     ],
                   ),
@@ -112,18 +116,27 @@ class _TitleScreenState extends State<TitleScreen> {
                   ),
                 ),
               ],
-            );
+            ).animate().fadeIn(duration: 1.seconds, delay: .3.seconds);
           },
         ),
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_04_f/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_04_f/lib/title_screen/title_screen_ui.dart
@@ -92,7 +92,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],

--- a/next-gen-ui/step_05_a/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_05_a/lib/title_screen/title_screen.dart
@@ -54,9 +54,10 @@ class _TitleScreenState extends State<TitleScreen> {
                 Image.asset(AssetPaths.titleBgBase),
 
                 /// Bg-Receive
-                _buildLitImage(
+                _LitImage(
                   color: orbColor,
                   imgSrc: AssetPaths.titleBgReceive,
+                  lightAmt: _finalReceiveLightAmt,
                 ),
 
                 /// Mg + Fg
@@ -64,38 +65,41 @@ class _TitleScreenState extends State<TitleScreen> {
                   child: Stack(
                     children: [
                       /// Mg-Base
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleMgBase,
                         color: orbColor,
+                        lightAmt: _finalReceiveLightAmt,
                       ),
 
                       /// Mg-Receive
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleMgReceive,
                         color: orbColor,
+                        lightAmt: _finalReceiveLightAmt,
                       ),
 
                       /// Mg-Emit
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleMgEmit,
-                        emit: true,
                         color: emitColor,
+                        lightAmt: _finalEmitLightAmt,
                       ),
 
                       /// Fg-Rocks
                       Image.asset(AssetPaths.titleFgBase),
 
                       /// Fg-Receive
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleFgReceive,
                         color: orbColor,
+                        lightAmt: _finalReceiveLightAmt,
                       ),
 
                       /// Fg-Emit
-                      _buildLitImage(
+                      _LitImage(
                         imgSrc: AssetPaths.titleFgEmit,
-                        emit: true,
                         color: emitColor,
+                        lightAmt: _finalEmitLightAmt,
                       ),
                     ],
                   ),
@@ -112,18 +116,27 @@ class _TitleScreenState extends State<TitleScreen> {
                   ),
                 ),
               ],
-            );
+            ).animate().fadeIn(duration: 1.seconds, delay: .3.seconds);
           },
         ),
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
-
     return ColorFiltered(
       colorFilter: ColorFilter.mode(
         hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_05_a/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_05_a/lib/title_screen/title_screen_ui.dart
@@ -95,7 +95,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],

--- a/next-gen-ui/step_05_b/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_05_b/lib/title_screen/title_screen.dart
@@ -144,9 +144,11 @@ class _TitleScreenState extends State<TitleScreen>
                   Image.asset(AssetPaths.titleBgBase),
 
                   /// Bg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     color: orbColor,
                     imgSrc: AssetPaths.titleBgReceive,
+                    pulseEffect: _pulseEffect,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Orb
@@ -174,38 +176,46 @@ class _TitleScreenState extends State<TitleScreen>
                     child: Stack(
                       children: [
                         /// Mg-Base
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleMgBase,
                           color: orbColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalReceiveLightAmt,
                         ),
 
                         /// Mg-Receive
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleMgReceive,
                           color: orbColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalReceiveLightAmt,
                         ),
 
                         /// Mg-Emit
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleMgEmit,
-                          emit: true,
                           color: emitColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalEmitLightAmt,
                         ),
 
                         /// Fg-Rocks
                         Image.asset(AssetPaths.titleFgBase),
 
                         /// Fg-Receive
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleFgReceive,
                           color: orbColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalReceiveLightAmt,
                         ),
 
                         /// Fg-Emit
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleFgEmit,
-                          emit: true,
                           color: emitColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalEmitLightAmt,
                         ),
                       ],
                     ),
@@ -229,15 +239,27 @@ class _TitleScreenState extends State<TitleScreen>
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.pulseEffect,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final AnimationController pulseEffect;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
     return ListenableBuilder(
-      listenable: _pulseEffect,
+      listenable: pulseEffect,
       child: Image.asset(imgSrc),
       builder: (context, child) {
-        final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
         return ColorFiltered(
           colorFilter: ColorFilter.mode(
             hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_05_b/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_05_b/lib/title_screen/title_screen_ui.dart
@@ -95,7 +95,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],

--- a/next-gen-ui/step_06/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_06/lib/title_screen/title_screen.dart
@@ -145,9 +145,11 @@ class _TitleScreenState extends State<TitleScreen>
                   Image.asset(AssetPaths.titleBgBase),
 
                   /// Bg-Receive
-                  _buildLitImage(
+                  _LitImage(
                     color: orbColor,
                     imgSrc: AssetPaths.titleBgReceive,
+                    pulseEffect: _pulseEffect,
+                    lightAmt: _finalReceiveLightAmt,
                   ),
 
                   /// Orb
@@ -175,22 +177,27 @@ class _TitleScreenState extends State<TitleScreen>
                     child: Stack(
                       children: [
                         /// Mg-Base
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleMgBase,
                           color: orbColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalReceiveLightAmt,
                         ),
 
                         /// Mg-Receive
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleMgReceive,
                           color: orbColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalReceiveLightAmt,
                         ),
 
                         /// Mg-Emit
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleMgEmit,
-                          emit: true,
                           color: emitColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalEmitLightAmt,
                         ),
 
                         /// Particle Field
@@ -210,16 +217,19 @@ class _TitleScreenState extends State<TitleScreen>
                         Image.asset(AssetPaths.titleFgBase),
 
                         /// Fg-Receive
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleFgReceive,
                           color: orbColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalReceiveLightAmt,
                         ),
 
                         /// Fg-Emit
-                        _buildLitImage(
+                        _LitImage(
                           imgSrc: AssetPaths.titleFgEmit,
-                          emit: true,
                           color: emitColor,
+                          pulseEffect: _pulseEffect,
+                          lightAmt: _finalEmitLightAmt,
                         ),
                       ],
                     ),
@@ -243,15 +253,27 @@ class _TitleScreenState extends State<TitleScreen>
       ),
     );
   }
+}
 
-  Widget _buildLitImage(
-      {required Color color, required String imgSrc, bool emit = false}) {
+class _LitImage extends StatelessWidget {
+  const _LitImage({
+    required this.color,
+    required this.imgSrc,
+    required this.pulseEffect,
+    required this.lightAmt,
+  });
+  final Color color;
+  final String imgSrc;
+  final AnimationController pulseEffect;
+  final double lightAmt;
+
+  @override
+  Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
     return ListenableBuilder(
-      listenable: _pulseEffect,
+      listenable: pulseEffect,
       child: Image.asset(imgSrc),
       builder: (context, child) {
-        final lightAmt = emit ? _finalEmitLightAmt : _finalReceiveLightAmt;
         return ColorFiltered(
           colorFilter: ColorFilter.mode(
             hsl.withLightness(hsl.lightness * lightAmt).toColor(),

--- a/next-gen-ui/step_06/lib/title_screen/title_screen_ui.dart
+++ b/next-gen-ui/step_06/lib/title_screen/title_screen_ui.dart
@@ -95,7 +95,7 @@ class _TitleText extends StatelessWidget {
             Image.asset(AssetPaths.titleSelectedRight, height: 65),
           ],
         ).animate().fadeIn(delay: .8.seconds, duration: .7.seconds),
-        Text('THE LAST STAND', style: TextStyles.h3)
+        Text('INTO THE UNKNOWN', style: TextStyles.h3)
             .animate()
             .fadeIn(delay: 1.seconds, duration: .7.seconds),
       ],


### PR DESCRIPTION
PTAL @craiglabenz 

This contains fixes for:
  - Re-titling `step_01` to 'Next-Generation'
  - Converting `_buildLitImage` into a widget
  - Re-titling the app from 'Outpost: The Last Stand' to 'Outpost: Into the Unknown' 
  - Fix for a lost animation

I'll update the codelab text tomorrow, but it'd help to have this landed beforehand. Thanks!

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
