### PR TITLE
Remove now unneeded `plugin_codelab` special handing

### DIFF
--- a/flutter_ci_script_beta.sh
+++ b/flutter_ci_script_beta.sh
@@ -42,11 +42,6 @@ declare -a CODELABS=(
   "webview_flutter"
   )
 
-# Plugin codelab is failing on ubuntu-latest in CI.
-if [[ "$OSTYPE" != "linux-gnu"* ]]; then
-  CODELABS+=("plugin_codelab")
-fi
-
 ci_codelabs "beta" "${CODELABS[@]}"
 
 echo "== END OF TESTS"

--- a/flutter_ci_script_stable.sh
+++ b/flutter_ci_script_stable.sh
@@ -35,11 +35,6 @@ declare -a CODELABS=(
   "webview_flutter"
   )
 
-# Plugin codelab is failing on ubuntu-latest in CI.
-if [[ "$OSTYPE" != "linux-gnu"* ]]; then
-  CODELABS+=("plugin_codelab")
-fi
-
 ci_codelabs "stable" "${CODELABS[@]}"
 
 echo "== END OF TESTS"


### PR DESCRIPTION
This special handling seems to no longer be needed, since `plugin_codelabs` is already existing in the main list since 3.7.0, meaning it's already running on all platforms.

Also fixes the build by properly ignoring `plugin_codelab` on the `beta` CI.
