### PR TITLE
use color filter more efficiently

### DIFF
--- a/next-gen-ui/step_02_b/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_02_b/lib/title_screen/title_screen.dart
@@ -60,12 +60,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_02_c/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_02_c/lib/title_screen/title_screen.dart
@@ -90,12 +90,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_03_a/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_03_a/lib/title_screen/title_screen.dart
@@ -96,12 +96,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_03_b/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_03_b/lib/title_screen/title_screen.dart
@@ -121,12 +121,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_03_c/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_03_c/lib/title_screen/title_screen.dart
@@ -121,12 +121,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_04_a/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_a/lib/title_screen/title_screen.dart
@@ -121,12 +121,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_04_b/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_b/lib/title_screen/title_screen.dart
@@ -121,12 +121,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_04_c/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_c/lib/title_screen/title_screen.dart
@@ -121,12 +121,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_04_d/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_d/lib/title_screen/title_screen.dart
@@ -121,12 +121,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_04_e/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_04_e/lib/title_screen/title_screen.dart
@@ -128,12 +128,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_05_a/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_05_a/lib/title_screen/title_screen.dart
@@ -128,12 +128,10 @@ class _LitImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hsl = HSLColor.fromColor(color);
-    return ColorFiltered(
-      colorFilter: ColorFilter.mode(
-        hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-        BlendMode.modulate,
-      ),
-      child: Image.asset(imgSrc),
+    return Image.asset(
+      imgSrc,
+      color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+      colorBlendMode: BlendMode.modulate,
     );
   }
 }

--- a/next-gen-ui/step_05_b/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_05_b/lib/title_screen/title_screen.dart
@@ -257,14 +257,11 @@ class _LitImage extends StatelessWidget {
     final hsl = HSLColor.fromColor(color);
     return ListenableBuilder(
       listenable: pulseEffect,
-      child: Image.asset(imgSrc),
       builder: (context, child) {
-        return ColorFiltered(
-          colorFilter: ColorFilter.mode(
-            hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-            BlendMode.modulate,
-          ),
-          child: child,
+        return Image.asset(
+          imgSrc,
+          color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+          colorBlendMode: BlendMode.modulate,
         );
       },
     );

--- a/next-gen-ui/step_06/lib/title_screen/title_screen.dart
+++ b/next-gen-ui/step_06/lib/title_screen/title_screen.dart
@@ -268,14 +268,11 @@ class _LitImage extends StatelessWidget {
     final hsl = HSLColor.fromColor(color);
     return ListenableBuilder(
       listenable: pulseEffect,
-      child: Image.asset(imgSrc),
       builder: (context, child) {
-        return ColorFiltered(
-          colorFilter: ColorFilter.mode(
-            hsl.withLightness(hsl.lightness * lightAmt).toColor(),
-            BlendMode.modulate,
-          ),
-          child: child,
+        return Image.asset(
+          imgSrc,
+          color: hsl.withLightness(hsl.lightness * lightAmt).toColor(),
+          colorBlendMode: BlendMode.modulate,
         );
       },
     );


### PR DESCRIPTION
This uses fewer reasources, because we apply the color filter with the image as an input, instead of drawing the image, then ending the render pass and feeding that into the color filter.