### PR TITLE
Use final instead var for `patterns-and-records`

### DIFF
--- a/dart-patterns-and-records/codelab_rebuild.yaml
+++ b/dart-patterns-and-records/codelab_rebuild.yaml
@@ -186,8 +186,8 @@ steps:
              Document() : _json = jsonDecode(documentJson);
           +
           +  (String, {DateTime modified}) get metadata {
-          +    var title = 'My Document';
-          +    var now = DateTime.now();
+          +    const title = 'My Document';
+          +    final now = DateTime.now();
           +
           +    return (title, modified: now);
           +  }
@@ -203,7 +203,7 @@ steps:
            
              @override
              Widget build(BuildContext context) {
-          +    var metadataRecord = document.metadata;
+          +    final metadataRecord = document.metadata;
           +
                return Scaffold(
                  appBar: AppBar(
@@ -244,8 +244,8 @@ steps:
            
              @override
              Widget build(BuildContext context) {
-          -    var metadataRecord = document.metadata;
-          +    var (title, modified: modified) = document.metadata;
+          -    final metadataRecord = document.metadata;
+          +    final (title, modified: modified) = document.metadata;
            
                return Scaffold(
                  appBar: AppBar(
@@ -284,8 +284,8 @@ steps:
            
              @override
              Widget build(BuildContext context) {
-          -    var (title, modified: modified) = document.metadata;
-          +    var (title, :modified) = document.metadata;
+          -    final (title, modified: modified) = document.metadata;
+          +    final (title, :modified) = document.metadata;
            
                return Scaffold(
                  appBar: AppBar(
@@ -312,15 +312,15 @@ steps:
              Document() : _json = jsonDecode(documentJson);
            
              (String, {DateTime modified}) get metadata {
-          -    var title = 'My Document';
-          -    var now = DateTime.now();
+          -    const title = 'My Document';
+          -    final now = DateTime.now();
           -
           -    return (title, modified: now);
           +    if (_json.containsKey('metadata')) {
-          +      var metadataJson = _json['metadata'];
+          +      final metadataJson = _json['metadata'];
           +      if (metadataJson is Map) {
-          +        var title = metadataJson['title'] as String;
-          +        var localModified = DateTime.parse(metadataJson['modified'] as String);
+          +        final title = metadataJson['title'] as String;
+          +        final localModified = DateTime.parse(metadataJson['modified'] as String);
           +        return (title, modified: localModified);
           +      }
           +    }
@@ -351,10 +351,10 @@ steps:
            
              (String, {DateTime modified}) get metadata {
           -    if (_json.containsKey('metadata')) {
-          -      var metadataJson = _json['metadata'];
+          -      final metadataJson = _json['metadata'];
           -      if (metadataJson is Map) {
-          -        var title = metadataJson['title'] as String;
-          -        var localModified = DateTime.parse(metadataJson['modified'] as String);
+          -        final title = metadataJson['title'] as String;
+          -        final localModified = DateTime.parse(metadataJson['modified'] as String);
           -        return (title, modified: localModified);
           -      }
           +    if (_json
@@ -397,7 +397,7 @@ steps:
           +
           +  List<Block> getBlocks() {
           +    if (_json case {'blocks': List blocksJson}) {
-          +      return [for (var blockJson in blocksJson) Block.fromJson(blockJson)];
+          +      return [for (final blockJson in blocksJson) Block.fromJson(blockJson)];
           +    } else {
           +      throw const FormatException('Unexpected JSON format');
           +    }
@@ -416,7 +416,7 @@ steps:
           +  Block(this.type, this.text);
           +
           +  factory Block.fromJson(Map<String, dynamic> json) {
-          +    if (json case {'type': var type, 'text': var text}) {
+          +    if (json case {'type': final type, 'text': final text}) {
           +      return Block(type, text);
           +    } else {
           +      throw const FormatException('Unexpected JSON format');
@@ -445,8 +445,8 @@ steps:
           @@ -35,6 +35,7 @@ class DocumentScreen extends StatelessWidget {
              @override
              Widget build(BuildContext context) {
-               var (title, :modified) = document.metadata;
-          +    var blocks = document.getBlocks();
+               final (title, :modified) = document.metadata;
+          +    final blocks = document.getBlocks();
            
                return Scaffold(
                  appBar: AppBar(
@@ -564,15 +564,15 @@ steps:
            }
            
           +String formatDate(DateTime dateTime) {
-          +  var today = DateTime.now();
-          +  var difference = dateTime.difference(today);
+          +  final today = DateTime.now();
+          +  final difference = dateTime.difference(today);
           +
           +  return switch (difference) {
           +    Duration(inDays: 0) => 'today',
           +    Duration(inDays: 1) => 'tomorrow',
           +    Duration(inDays: -1) => 'yesterday',
-          +    Duration(inDays: var days, isNegative: true) => '${days.abs()} days ago',
-          +    Duration(inDays: var days) => '$days days from now',
+          +    Duration(inDays: final days, isNegative: true) => '${days.abs()} days ago',
+          +    Duration(inDays: final days) => '$days days from now',
           +  };
           +}
           +
@@ -601,17 +601,17 @@ steps:
                Duration(inDays: 0) => 'today',
                Duration(inDays: 1) => 'tomorrow',
                Duration(inDays: -1) => 'yesterday',
-          +    Duration(inDays: var days) when days > 7 => '${days ~/ 7} weeks from now',
-          +    Duration(inDays: var days) when days < -7 => '${days.abs() ~/ 7} weeks ago',
-               Duration(inDays: var days, isNegative: true) => '${days.abs()} days ago',
-               Duration(inDays: var days) => '$days days from now',
+          +    Duration(inDays: final days) when days > 7 => '${days ~/ 7} weeks from now',
+          +    Duration(inDays: final days) when days < -7 => '${days.abs() ~/ 7} weeks ago',
+               Duration(inDays: final days, isNegative: true) => '${days.abs()} days ago',
+               Duration(inDays: final days) => '$days days from now',
              };
           @@ -48,6 +50,7 @@ class DocumentScreen extends StatelessWidget {
              @override
              Widget build(BuildContext context) {
-               var (title, :modified) = document.metadata;
-          +    var formattedModifiedDate = formatDate(modified);
-               var blocks = document.getBlocks();
+               final (title, :modified) = document.metadata;
+          +    final formattedModifiedDate = formatDate(modified);
+               final blocks = document.getBlocks();
            
                return Scaffold(
           @@ -56,7 +59,7 @@ class DocumentScreen extends StatelessWidget {
@@ -654,7 +654,7 @@ steps:
           +  Block();
            
           -  factory Block.fromJson(Map<String, dynamic> json) {
-          -    if (json case {'type': var type, 'text': var text}) {
+          -    if (json case {'type': final type, 'text': final text}) {
           -      return Block(type, text);
           -    } else {
           -      throw const FormatException('Unexpected JSON format');
@@ -708,12 +708,12 @@ steps:
           -        style: textStyle,
           -      ),
           +      child: switch (block) {
-          +        HeaderBlock(:var text) => Text(
+          +        HeaderBlock(:final text) => Text(
           +            text,
           +            style: Theme.of(context).textTheme.displayMedium,
           +          ),
-          +        ParagraphBlock(:var text) => Text(text),
-          +        CheckboxBlock(:var text, :var isChecked) => Row(
+          +        ParagraphBlock(:final text) => Text(text),
+          +        CheckboxBlock(:final text, :final isChecked) => Row(
           +            children: [
           +              Checkbox(value: isChecked, onChanged: (_) {}),
           +              Text(text),

--- a/dart-patterns-and-records/codelab_rebuild.yaml
+++ b/dart-patterns-and-records/codelab_rebuild.yaml
@@ -20,6 +20,12 @@ steps:
             language:
               strict-casts: false
               strict-inference: false
+          
+          linter:
+            rules:
+              prefer_final_in_for_each
+              prefer_final_locals
+              prefer_final_parameters
       - name: Remove README
         rm: patterns_codelab/README.md
       - name: Patch lib/main.dart
@@ -308,7 +314,7 @@ steps:
         patch-u: |
           --- b/dart-patterns-and-records/step_07_a/lib/data.dart
           +++ a/dart-patterns-and-records/step_07_a/lib/data.dart
-          @@ -9,10 +9,15 @@ class Document {
+          @@ -9,10 +9,16 @@ class Document {
              Document() : _json = jsonDecode(documentJson);
            
              (String, {DateTime modified}) get metadata {
@@ -320,7 +326,8 @@ steps:
           +      final metadataJson = _json['metadata'];
           +      if (metadataJson is Map) {
           +        final title = metadataJson['title'] as String;
-          +        final localModified = DateTime.parse(metadataJson['modified'] as String);
+          +        final localModified =
+          +            DateTime.parse(metadataJson['modified'] as String);
           +        return (title, modified: localModified);
           +      }
           +    }
@@ -346,7 +353,7 @@ steps:
         patch-u: |
           --- b/dart-patterns-and-records/step_07_b/lib/data.dart
           +++ a/dart-patterns-and-records/step_07_b/lib/data.dart
-          @@ -9,15 +9,17 @@ class Document {
+          @@ -9,16 +9,17 @@ class Document {
              Document() : _json = jsonDecode(documentJson);
            
              (String, {DateTime modified}) get metadata {
@@ -354,7 +361,8 @@ steps:
           -      final metadataJson = _json['metadata'];
           -      if (metadataJson is Map) {
           -        final title = metadataJson['title'] as String;
-          -        final localModified = DateTime.parse(metadataJson['modified'] as String);
+          -        final localModified =
+          -            DateTime.parse(metadataJson['modified'] as String);
           -        return (title, modified: localModified);
           -      }
           +    if (_json
@@ -597,16 +605,17 @@ steps:
         patch-u: |
           --- b/dart-patterns-and-records/step_11_b/lib/main.dart
           +++ a/dart-patterns-and-records/step_11_b/lib/main.dart
-          @@ -18,6 +18,8 @@ String formatDate(DateTime dateTime) {
+          @@ -18,6 +18,9 @@ String formatDate(DateTime dateTime) {
                Duration(inDays: 0) => 'today',
                Duration(inDays: 1) => 'tomorrow',
                Duration(inDays: -1) => 'yesterday',
           +    Duration(inDays: final days) when days > 7 => '${days ~/ 7} weeks from now',
-          +    Duration(inDays: final days) when days < -7 => '${days.abs() ~/ 7} weeks ago',
+          +    Duration(inDays: final days) when days < -7 =>
+          +      '${days.abs() ~/ 7} weeks ago',
                Duration(inDays: final days, isNegative: true) => '${days.abs()} days ago',
                Duration(inDays: final days) => '$days days from now',
              };
-          @@ -48,6 +50,7 @@ class DocumentScreen extends StatelessWidget {
+          @@ -48,6 +51,7 @@ class DocumentScreen extends StatelessWidget {
              @override
              Widget build(BuildContext context) {
                final (title, :modified) = document.metadata;
@@ -614,7 +623,7 @@ steps:
                final blocks = document.getBlocks();
            
                return Scaffold(
-          @@ -56,7 +59,7 @@ class DocumentScreen extends StatelessWidget {
+          @@ -56,7 +60,7 @@ class DocumentScreen extends StatelessWidget {
                  ),
                  body: Column(
                    children: [
@@ -690,7 +699,7 @@ steps:
         patch-u: |
           --- b/dart-patterns-and-records/step_12/lib/main.dart
           +++ a/dart-patterns-and-records/step_12/lib/main.dart
-          @@ -84,19 +84,21 @@ class BlockWidget extends StatelessWidget {
+          @@ -85,19 +85,21 @@ class BlockWidget extends StatelessWidget {
            
              @override
              Widget build(BuildContext context) {

--- a/dart-patterns-and-records/step_03/analysis_options.yaml
+++ b/dart-patterns-and-records/step_03/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_04/analysis_options.yaml
+++ b/dart-patterns-and-records/step_04/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_05/analysis_options.yaml
+++ b/dart-patterns-and-records/step_05/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_05/lib/data.dart
+++ b/dart-patterns-and-records/step_05/lib/data.dart
@@ -9,8 +9,8 @@ class Document {
   Document() : _json = jsonDecode(documentJson);
 
   (String, {DateTime modified}) get metadata {
-    var title = 'My Document';
-    var now = DateTime.now();
+    const title = 'My Document';
+    final now = DateTime.now();
 
     return (title, modified: now);
   }

--- a/dart-patterns-and-records/step_05/lib/main.dart
+++ b/dart-patterns-and-records/step_05/lib/main.dart
@@ -34,7 +34,7 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var metadataRecord = document.metadata;
+    final metadataRecord = document.metadata;
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_06_a/analysis_options.yaml
+++ b/dart-patterns-and-records/step_06_a/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_06_a/lib/data.dart
+++ b/dart-patterns-and-records/step_06_a/lib/data.dart
@@ -9,8 +9,8 @@ class Document {
   Document() : _json = jsonDecode(documentJson);
 
   (String, {DateTime modified}) get metadata {
-    var title = 'My Document';
-    var now = DateTime.now();
+    const title = 'My Document';
+    final now = DateTime.now();
 
     return (title, modified: now);
   }

--- a/dart-patterns-and-records/step_06_a/lib/main.dart
+++ b/dart-patterns-and-records/step_06_a/lib/main.dart
@@ -34,7 +34,7 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, modified: modified) = document.metadata;
+    final (title, modified: modified) = document.metadata;
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_06_b/analysis_options.yaml
+++ b/dart-patterns-and-records/step_06_b/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_06_b/lib/data.dart
+++ b/dart-patterns-and-records/step_06_b/lib/data.dart
@@ -9,8 +9,8 @@ class Document {
   Document() : _json = jsonDecode(documentJson);
 
   (String, {DateTime modified}) get metadata {
-    var title = 'My Document';
-    var now = DateTime.now();
+    const title = 'My Document';
+    final now = DateTime.now();
 
     return (title, modified: now);
   }

--- a/dart-patterns-and-records/step_06_b/lib/main.dart
+++ b/dart-patterns-and-records/step_06_b/lib/main.dart
@@ -34,7 +34,7 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
+    final (title, :modified) = document.metadata;
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_07_a/analysis_options.yaml
+++ b/dart-patterns-and-records/step_07_a/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_07_a/lib/data.dart
+++ b/dart-patterns-and-records/step_07_a/lib/data.dart
@@ -10,10 +10,11 @@ class Document {
 
   (String, {DateTime modified}) get metadata {
     if (_json.containsKey('metadata')) {
-      var metadataJson = _json['metadata'];
+      final metadataJson = _json['metadata'];
       if (metadataJson is Map) {
-        var title = metadataJson['title'] as String;
-        var localModified = DateTime.parse(metadataJson['modified'] as String);
+        final title = metadataJson['title'] as String;
+        final localModified =
+            DateTime.parse(metadataJson['modified'] as String);
         return (title, modified: localModified);
       }
     }

--- a/dart-patterns-and-records/step_07_a/lib/main.dart
+++ b/dart-patterns-and-records/step_07_a/lib/main.dart
@@ -34,7 +34,7 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
+    final (title, :modified) = document.metadata;
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_07_b/analysis_options.yaml
+++ b/dart-patterns-and-records/step_07_b/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_07_b/lib/main.dart
+++ b/dart-patterns-and-records/step_07_b/lib/main.dart
@@ -34,7 +34,7 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
+    final (title, :modified) = document.metadata;
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_08/analysis_options.yaml
+++ b/dart-patterns-and-records/step_08/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_08/lib/data.dart
+++ b/dart-patterns-and-records/step_08/lib/data.dart
@@ -24,7 +24,7 @@ class Document {
 
   List<Block> getBlocks() {
     if (_json case {'blocks': List blocksJson}) {
-      return [for (var blockJson in blocksJson) Block.fromJson(blockJson)];
+      return [for (final blockJson in blocksJson) Block.fromJson(blockJson)];
     } else {
       throw const FormatException('Unexpected JSON format');
     }
@@ -61,7 +61,7 @@ class Block {
   Block(this.type, this.text);
 
   factory Block.fromJson(Map<String, dynamic> json) {
-    if (json case {'type': var type, 'text': var text}) {
+    if (json case {'type': final type, 'text': final text}) {
       return Block(type, text);
     } else {
       throw const FormatException('Unexpected JSON format');

--- a/dart-patterns-and-records/step_08/lib/main.dart
+++ b/dart-patterns-and-records/step_08/lib/main.dart
@@ -34,7 +34,7 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
+    final (title, :modified) = document.metadata;
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_09/analysis_options.yaml
+++ b/dart-patterns-and-records/step_09/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_09/lib/data.dart
+++ b/dart-patterns-and-records/step_09/lib/data.dart
@@ -24,7 +24,7 @@ class Document {
 
   List<Block> getBlocks() {
     if (_json case {'blocks': List blocksJson}) {
-      return [for (var blockJson in blocksJson) Block.fromJson(blockJson)];
+      return [for (final blockJson in blocksJson) Block.fromJson(blockJson)];
     } else {
       throw const FormatException('Unexpected JSON format');
     }
@@ -61,7 +61,7 @@ class Block {
   Block(this.type, this.text);
 
   factory Block.fromJson(Map<String, dynamic> json) {
-    if (json case {'type': var type, 'text': var text}) {
+    if (json case {'type': final type, 'text': final text}) {
       return Block(type, text);
     } else {
       throw const FormatException('Unexpected JSON format');

--- a/dart-patterns-and-records/step_09/lib/main.dart
+++ b/dart-patterns-and-records/step_09/lib/main.dart
@@ -34,8 +34,8 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
-    var blocks = document.getBlocks();
+    final (title, :modified) = document.metadata;
+    final blocks = document.getBlocks();
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_10/analysis_options.yaml
+++ b/dart-patterns-and-records/step_10/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_10/lib/data.dart
+++ b/dart-patterns-and-records/step_10/lib/data.dart
@@ -24,7 +24,7 @@ class Document {
 
   List<Block> getBlocks() {
     if (_json case {'blocks': List blocksJson}) {
-      return [for (var blockJson in blocksJson) Block.fromJson(blockJson)];
+      return [for (final blockJson in blocksJson) Block.fromJson(blockJson)];
     } else {
       throw const FormatException('Unexpected JSON format');
     }
@@ -61,7 +61,7 @@ class Block {
   Block(this.type, this.text);
 
   factory Block.fromJson(Map<String, dynamic> json) {
-    if (json case {'type': var type, 'text': var text}) {
+    if (json case {'type': final type, 'text': final text}) {
       return Block(type, text);
     } else {
       throw const FormatException('Unexpected JSON format');

--- a/dart-patterns-and-records/step_10/lib/main.dart
+++ b/dart-patterns-and-records/step_10/lib/main.dart
@@ -34,8 +34,8 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
-    var blocks = document.getBlocks();
+    final (title, :modified) = document.metadata;
+    final blocks = document.getBlocks();
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_11_a/analysis_options.yaml
+++ b/dart-patterns-and-records/step_11_a/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_11_a/lib/data.dart
+++ b/dart-patterns-and-records/step_11_a/lib/data.dart
@@ -24,7 +24,7 @@ class Document {
 
   List<Block> getBlocks() {
     if (_json case {'blocks': List blocksJson}) {
-      return [for (var blockJson in blocksJson) Block.fromJson(blockJson)];
+      return [for (final blockJson in blocksJson) Block.fromJson(blockJson)];
     } else {
       throw const FormatException('Unexpected JSON format');
     }
@@ -61,7 +61,7 @@ class Block {
   Block(this.type, this.text);
 
   factory Block.fromJson(Map<String, dynamic> json) {
-    if (json case {'type': var type, 'text': var text}) {
+    if (json case {'type': final type, 'text': final text}) {
       return Block(type, text);
     } else {
       throw const FormatException('Unexpected JSON format');

--- a/dart-patterns-and-records/step_11_a/lib/main.dart
+++ b/dart-patterns-and-records/step_11_a/lib/main.dart
@@ -11,15 +11,15 @@ void main() {
 }
 
 String formatDate(DateTime dateTime) {
-  var today = DateTime.now();
-  var difference = dateTime.difference(today);
+  final today = DateTime.now();
+  final difference = dateTime.difference(today);
 
   return switch (difference) {
     Duration(inDays: 0) => 'today',
     Duration(inDays: 1) => 'tomorrow',
     Duration(inDays: -1) => 'yesterday',
-    Duration(inDays: var days, isNegative: true) => '${days.abs()} days ago',
-    Duration(inDays: var days) => '$days days from now',
+    Duration(inDays: final days, isNegative: true) => '${days.abs()} days ago',
+    Duration(inDays: final days) => '$days days from now',
   };
 }
 
@@ -47,8 +47,8 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
-    var blocks = document.getBlocks();
+    final (title, :modified) = document.metadata;
+    final blocks = document.getBlocks();
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_11_b/analysis_options.yaml
+++ b/dart-patterns-and-records/step_11_b/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_11_b/lib/data.dart
+++ b/dart-patterns-and-records/step_11_b/lib/data.dart
@@ -24,7 +24,7 @@ class Document {
 
   List<Block> getBlocks() {
     if (_json case {'blocks': List blocksJson}) {
-      return [for (var blockJson in blocksJson) Block.fromJson(blockJson)];
+      return [for (final blockJson in blocksJson) Block.fromJson(blockJson)];
     } else {
       throw const FormatException('Unexpected JSON format');
     }
@@ -61,7 +61,7 @@ class Block {
   Block(this.type, this.text);
 
   factory Block.fromJson(Map<String, dynamic> json) {
-    if (json case {'type': var type, 'text': var text}) {
+    if (json case {'type': final type, 'text': final text}) {
       return Block(type, text);
     } else {
       throw const FormatException('Unexpected JSON format');

--- a/dart-patterns-and-records/step_11_b/lib/main.dart
+++ b/dart-patterns-and-records/step_11_b/lib/main.dart
@@ -11,17 +11,18 @@ void main() {
 }
 
 String formatDate(DateTime dateTime) {
-  var today = DateTime.now();
-  var difference = dateTime.difference(today);
+  final today = DateTime.now();
+  final difference = dateTime.difference(today);
 
   return switch (difference) {
     Duration(inDays: 0) => 'today',
     Duration(inDays: 1) => 'tomorrow',
     Duration(inDays: -1) => 'yesterday',
-    Duration(inDays: var days) when days > 7 => '${days ~/ 7} weeks from now',
-    Duration(inDays: var days) when days < -7 => '${days.abs() ~/ 7} weeks ago',
-    Duration(inDays: var days, isNegative: true) => '${days.abs()} days ago',
-    Duration(inDays: var days) => '$days days from now',
+    Duration(inDays: final days) when days > 7 => '${days ~/ 7} weeks from now',
+    Duration(inDays: final days) when days < -7 =>
+      '${days.abs() ~/ 7} weeks ago',
+    Duration(inDays: final days, isNegative: true) => '${days.abs()} days ago',
+    Duration(inDays: final days) => '$days days from now',
   };
 }
 
@@ -49,9 +50,9 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
-    var formattedModifiedDate = formatDate(modified);
-    var blocks = document.getBlocks();
+    final (title, :modified) = document.metadata;
+    final formattedModifiedDate = formatDate(modified);
+    final blocks = document.getBlocks();
 
     return Scaffold(
       appBar: AppBar(

--- a/dart-patterns-and-records/step_12/analysis_options.yaml
+++ b/dart-patterns-and-records/step_12/analysis_options.yaml
@@ -6,3 +6,9 @@ analyzer:
   language:
     strict-casts: false
     strict-inference: false
+
+linter:
+  rules:
+    prefer_final_in_for_each
+    prefer_final_locals
+    prefer_final_parameters

--- a/dart-patterns-and-records/step_12/lib/data.dart
+++ b/dart-patterns-and-records/step_12/lib/data.dart
@@ -24,7 +24,7 @@ class Document {
 
   List<Block> getBlocks() {
     if (_json case {'blocks': List blocksJson}) {
-      return [for (var blockJson in blocksJson) Block.fromJson(blockJson)];
+      return [for (final blockJson in blocksJson) Block.fromJson(blockJson)];
     } else {
       throw const FormatException('Unexpected JSON format');
     }

--- a/dart-patterns-and-records/step_12/lib/main.dart
+++ b/dart-patterns-and-records/step_12/lib/main.dart
@@ -11,17 +11,18 @@ void main() {
 }
 
 String formatDate(DateTime dateTime) {
-  var today = DateTime.now();
-  var difference = dateTime.difference(today);
+  final today = DateTime.now();
+  final difference = dateTime.difference(today);
 
   return switch (difference) {
     Duration(inDays: 0) => 'today',
     Duration(inDays: 1) => 'tomorrow',
     Duration(inDays: -1) => 'yesterday',
-    Duration(inDays: var days) when days > 7 => '${days ~/ 7} weeks from now',
-    Duration(inDays: var days) when days < -7 => '${days.abs() ~/ 7} weeks ago',
-    Duration(inDays: var days, isNegative: true) => '${days.abs()} days ago',
-    Duration(inDays: var days) => '$days days from now',
+    Duration(inDays: final days) when days > 7 => '${days ~/ 7} weeks from now',
+    Duration(inDays: final days) when days < -7 =>
+      '${days.abs() ~/ 7} weeks ago',
+    Duration(inDays: final days, isNegative: true) => '${days.abs()} days ago',
+    Duration(inDays: final days) => '$days days from now',
   };
 }
 
@@ -49,9 +50,9 @@ class DocumentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var (title, :modified) = document.metadata;
-    var formattedModifiedDate = formatDate(modified);
-    var blocks = document.getBlocks();
+    final (title, :modified) = document.metadata;
+    final formattedModifiedDate = formatDate(modified);
+    final blocks = document.getBlocks();
 
     return Scaffold(
       appBar: AppBar(
@@ -87,12 +88,12 @@ class BlockWidget extends StatelessWidget {
     return Container(
       margin: const EdgeInsets.all(8),
       child: switch (block) {
-        HeaderBlock(:var text) => Text(
+        HeaderBlock(:final text) => Text(
             text,
             style: Theme.of(context).textTheme.displayMedium,
           ),
-        ParagraphBlock(:var text) => Text(text),
-        CheckboxBlock(:var text, :var isChecked) => Row(
+        ParagraphBlock(:final text) => Text(text),
+        CheckboxBlock(:final text, :final isChecked) => Row(
             children: [
               Checkbox(value: isChecked, onChanged: (_) {}),
               Text(text),


### PR DESCRIPTION
The examples in the `dart-patterns-and-records` is using `var` but I think we should recommend using `final` where it's applicable. The PR is simply updating them.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
