### PR TITLE
`cupertino_store` to Dart 3 patterns and registers

### DIFF
--- a/cupertino_store/codelab_rebuild.yaml
+++ b/cupertino_store/codelab_rebuild.yaml
@@ -305,7 +305,7 @@ steps:
            
            class CupertinoStoreApp extends StatelessWidget {
              const CupertinoStoreApp({super.key});
-          @@ -37,11 +40,47 @@ class CupertinoStoreHomePage extends StatelessWidget {
+          @@ -37,11 +40,43 @@ class CupertinoStoreHomePage extends StatelessWidget {
            
              @override
              Widget build(BuildContext context) {
@@ -331,28 +331,24 @@ steps:
                  ),
           -      child: SizedBox(),
           +      tabBuilder: (context, index) {
-          +        late final CupertinoTabView returnValue;
-          +        switch (index) {
-          +          case 0:
-          +            returnValue = CupertinoTabView(builder: (context) {
-          +              return const CupertinoPageScaffold(
+          +        return switch (index) {
+          +          0 => CupertinoTabView(
+          +              builder: (context) => const CupertinoPageScaffold(
           +                child: ProductListTab(),
-          +              );
-          +            });
-          +          case 1:
-          +            returnValue = CupertinoTabView(builder: (context) {
-          +              return const CupertinoPageScaffold(
+          +              ),
+          +            ),
+          +          1 => CupertinoTabView(
+          +              builder: (context) => const CupertinoPageScaffold(
           +                child: SearchTab(),
-          +              );
-          +            });
-          +          case 2:
-          +            returnValue = CupertinoTabView(builder: (context) {
-          +              return const CupertinoPageScaffold(
+          +              ),
+          +            ),
+          +          2 => CupertinoTabView(
+          +              builder: (context) => const CupertinoPageScaffold(
           +                child: ShoppingCartTab(),
-          +              );
-          +            });
-          +        }
-          +        return returnValue;
+          +              ),
+          +            ),
+          +          _ => throw Exception('Invalid index $index'),
+          +        };
           +      },
                );
              }
@@ -616,15 +612,12 @@ steps:
             }
 
             // Returns a copy of the list of available products, filtered by category.
-            List<Product> getProducts() {
-              if (_selectedCategory == Category.all) {
-                return List.from(_availableProducts);
-              } else {
-                return _availableProducts.where((p) {
-                  return p.category == _selectedCategory;
-                }).toList();
-              }
-            }
+            List<Product> getProducts() => switch (_selectedCategory) {
+                  Category.all => List.from(_availableProducts),
+                  _ => _availableProducts
+                      .where((p) => p.category == _selectedCategory)
+                      .toList(),
+                };
 
             // Search the product catalog
             List<Product> search(String searchTerms) {
@@ -1013,13 +1006,10 @@ steps:
               ),
             ];
 
-            static List<Product> loadProducts(Category category) {
-              if (category == Category.all) {
-                return _allProducts;
-              } else {
-                return _allProducts.where((p) => p.category == category).toList();
-              }
-            }
+            static List<Product> loadProducts(Category category) => switch (category) {
+                  Category.all => _allProducts,
+                  _ => _allProducts.where((p) => p.category == category).toList(),
+                };
           }
       - name: Copy step_01
         copydir:

--- a/cupertino_store/step_00/pubspec.yaml
+++ b/cupertino_store/step_00/pubspec.yaml
@@ -34,7 +34,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.0.2 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/cupertino_store/step_01/lib/app.dart
+++ b/cupertino_store/step_01/lib/app.dart
@@ -58,28 +58,24 @@ class CupertinoStoreHomePage extends StatelessWidget {
         ],
       ),
       tabBuilder: (context, index) {
-        late final CupertinoTabView returnValue;
-        switch (index) {
-          case 0:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+        return switch (index) {
+          0 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ProductListTab(),
-              );
-            });
-          case 1:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          1 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: SearchTab(),
-              );
-            });
-          case 2:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          2 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ShoppingCartTab(),
-              );
-            });
-        }
-        return returnValue;
+              ),
+            ),
+          _ => throw Exception('Invalid index $index'),
+        };
       },
     );
   }

--- a/cupertino_store/step_01/lib/model/app_state_model.dart
+++ b/cupertino_store/step_01/lib/model/app_state_model.dart
@@ -74,15 +74,12 @@ class AppStateModel extends foundation.ChangeNotifier {
   }
 
   // Returns a copy of the list of available products, filtered by category.
-  List<Product> getProducts() {
-    if (_selectedCategory == Category.all) {
-      return List.from(_availableProducts);
-    } else {
-      return _availableProducts.where((p) {
-        return p.category == _selectedCategory;
-      }).toList();
-    }
-  }
+  List<Product> getProducts() => switch (_selectedCategory) {
+        Category.all => List.from(_availableProducts),
+        _ => _availableProducts
+            .where((p) => p.category == _selectedCategory)
+            .toList(),
+      };
 
   // Search the product catalog
   List<Product> search(String searchTerms) {

--- a/cupertino_store/step_01/lib/model/products_repository.dart
+++ b/cupertino_store/step_01/lib/model/products_repository.dart
@@ -284,11 +284,8 @@ class ProductsRepository {
     ),
   ];
 
-  static List<Product> loadProducts(Category category) {
-    if (category == Category.all) {
-      return _allProducts;
-    } else {
-      return _allProducts.where((p) => p.category == category).toList();
-    }
-  }
+  static List<Product> loadProducts(Category category) => switch (category) {
+        Category.all => _allProducts,
+        _ => _allProducts.where((p) => p.category == category).toList(),
+      };
 }

--- a/cupertino_store/step_01/pubspec.yaml
+++ b/cupertino_store/step_01/pubspec.yaml
@@ -34,7 +34,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.0.2 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/cupertino_store/step_02/lib/app.dart
+++ b/cupertino_store/step_02/lib/app.dart
@@ -58,28 +58,24 @@ class CupertinoStoreHomePage extends StatelessWidget {
         ],
       ),
       tabBuilder: (context, index) {
-        late final CupertinoTabView returnValue;
-        switch (index) {
-          case 0:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+        return switch (index) {
+          0 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ProductListTab(),
-              );
-            });
-          case 1:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          1 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: SearchTab(),
-              );
-            });
-          case 2:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          2 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ShoppingCartTab(),
-              );
-            });
-        }
-        return returnValue;
+              ),
+            ),
+          _ => throw Exception('Invalid index $index'),
+        };
       },
     );
   }

--- a/cupertino_store/step_02/lib/model/app_state_model.dart
+++ b/cupertino_store/step_02/lib/model/app_state_model.dart
@@ -74,15 +74,12 @@ class AppStateModel extends foundation.ChangeNotifier {
   }
 
   // Returns a copy of the list of available products, filtered by category.
-  List<Product> getProducts() {
-    if (_selectedCategory == Category.all) {
-      return List.from(_availableProducts);
-    } else {
-      return _availableProducts.where((p) {
-        return p.category == _selectedCategory;
-      }).toList();
-    }
-  }
+  List<Product> getProducts() => switch (_selectedCategory) {
+        Category.all => List.from(_availableProducts),
+        _ => _availableProducts
+            .where((p) => p.category == _selectedCategory)
+            .toList(),
+      };
 
   // Search the product catalog
   List<Product> search(String searchTerms) {

--- a/cupertino_store/step_02/lib/model/products_repository.dart
+++ b/cupertino_store/step_02/lib/model/products_repository.dart
@@ -284,11 +284,8 @@ class ProductsRepository {
     ),
   ];
 
-  static List<Product> loadProducts(Category category) {
-    if (category == Category.all) {
-      return _allProducts;
-    } else {
-      return _allProducts.where((p) => p.category == category).toList();
-    }
-  }
+  static List<Product> loadProducts(Category category) => switch (category) {
+        Category.all => _allProducts,
+        _ => _allProducts.where((p) => p.category == category).toList(),
+      };
 }

--- a/cupertino_store/step_02/pubspec.yaml
+++ b/cupertino_store/step_02/pubspec.yaml
@@ -34,7 +34,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.0.2 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/cupertino_store/step_03/lib/app.dart
+++ b/cupertino_store/step_03/lib/app.dart
@@ -58,28 +58,24 @@ class CupertinoStoreHomePage extends StatelessWidget {
         ],
       ),
       tabBuilder: (context, index) {
-        late final CupertinoTabView returnValue;
-        switch (index) {
-          case 0:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+        return switch (index) {
+          0 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ProductListTab(),
-              );
-            });
-          case 1:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          1 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: SearchTab(),
-              );
-            });
-          case 2:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          2 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ShoppingCartTab(),
-              );
-            });
-        }
-        return returnValue;
+              ),
+            ),
+          _ => throw Exception('Invalid index $index'),
+        };
       },
     );
   }

--- a/cupertino_store/step_03/lib/model/app_state_model.dart
+++ b/cupertino_store/step_03/lib/model/app_state_model.dart
@@ -74,15 +74,12 @@ class AppStateModel extends foundation.ChangeNotifier {
   }
 
   // Returns a copy of the list of available products, filtered by category.
-  List<Product> getProducts() {
-    if (_selectedCategory == Category.all) {
-      return List.from(_availableProducts);
-    } else {
-      return _availableProducts.where((p) {
-        return p.category == _selectedCategory;
-      }).toList();
-    }
-  }
+  List<Product> getProducts() => switch (_selectedCategory) {
+        Category.all => List.from(_availableProducts),
+        _ => _availableProducts
+            .where((p) => p.category == _selectedCategory)
+            .toList(),
+      };
 
   // Search the product catalog
   List<Product> search(String searchTerms) {

--- a/cupertino_store/step_03/lib/model/products_repository.dart
+++ b/cupertino_store/step_03/lib/model/products_repository.dart
@@ -284,7 +284,7 @@ class ProductsRepository {
     ),
   ];
 
-static List<Product> loadProducts(Category category) => switch (category) {
+  static List<Product> loadProducts(Category category) => switch (category) {
         Category.all => _allProducts,
         _ => _allProducts.where((p) => p.category == category).toList(),
       };

--- a/cupertino_store/step_03/lib/model/products_repository.dart
+++ b/cupertino_store/step_03/lib/model/products_repository.dart
@@ -284,11 +284,8 @@ class ProductsRepository {
     ),
   ];
 
-  static List<Product> loadProducts(Category category) {
-    if (category == Category.all) {
-      return _allProducts;
-    } else {
-      return _allProducts.where((p) => p.category == category).toList();
-    }
-  }
+static List<Product> loadProducts(Category category) => switch (category) {
+        Category.all => _allProducts,
+        _ => _allProducts.where((p) => p.category == category).toList(),
+      };
 }

--- a/cupertino_store/step_03/pubspec.yaml
+++ b/cupertino_store/step_03/pubspec.yaml
@@ -34,7 +34,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.0.2 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/cupertino_store/step_04/lib/app.dart
+++ b/cupertino_store/step_04/lib/app.dart
@@ -58,28 +58,24 @@ class CupertinoStoreHomePage extends StatelessWidget {
         ],
       ),
       tabBuilder: (context, index) {
-        late final CupertinoTabView returnValue;
-        switch (index) {
-          case 0:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+        return switch (index) {
+          0 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ProductListTab(),
-              );
-            });
-          case 1:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          1 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: SearchTab(),
-              );
-            });
-          case 2:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          2 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ShoppingCartTab(),
-              );
-            });
-        }
-        return returnValue;
+              ),
+            ),
+          _ => throw Exception('Invalid index $index'),
+        };
       },
     );
   }

--- a/cupertino_store/step_04/lib/model/app_state_model.dart
+++ b/cupertino_store/step_04/lib/model/app_state_model.dart
@@ -74,15 +74,12 @@ class AppStateModel extends foundation.ChangeNotifier {
   }
 
   // Returns a copy of the list of available products, filtered by category.
-  List<Product> getProducts() {
-    if (_selectedCategory == Category.all) {
-      return List.from(_availableProducts);
-    } else {
-      return _availableProducts.where((p) {
-        return p.category == _selectedCategory;
-      }).toList();
-    }
-  }
+  List<Product> getProducts() => switch (_selectedCategory) {
+        Category.all => List.from(_availableProducts),
+        _ => _availableProducts
+            .where((p) => p.category == _selectedCategory)
+            .toList(),
+      };
 
   // Search the product catalog
   List<Product> search(String searchTerms) {

--- a/cupertino_store/step_04/lib/model/products_repository.dart
+++ b/cupertino_store/step_04/lib/model/products_repository.dart
@@ -284,11 +284,8 @@ class ProductsRepository {
     ),
   ];
 
-  static List<Product> loadProducts(Category category) {
-    if (category == Category.all) {
-      return _allProducts;
-    } else {
-      return _allProducts.where((p) => p.category == category).toList();
-    }
-  }
+  static List<Product> loadProducts(Category category) => switch (category) {
+        Category.all => _allProducts,
+        _ => _allProducts.where((p) => p.category == category).toList(),
+      };
 }

--- a/cupertino_store/step_04/pubspec.yaml
+++ b/cupertino_store/step_04/pubspec.yaml
@@ -34,7 +34,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.0.2 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/cupertino_store/step_05/lib/app.dart
+++ b/cupertino_store/step_05/lib/app.dart
@@ -58,28 +58,24 @@ class CupertinoStoreHomePage extends StatelessWidget {
         ],
       ),
       tabBuilder: (context, index) {
-        late final CupertinoTabView returnValue;
-        switch (index) {
-          case 0:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+        return switch (index) {
+          0 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ProductListTab(),
-              );
-            });
-          case 1:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          1 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: SearchTab(),
-              );
-            });
-          case 2:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          2 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ShoppingCartTab(),
-              );
-            });
-        }
-        return returnValue;
+              ),
+            ),
+          _ => throw Exception('Invalid index $index'),
+        };
       },
     );
   }

--- a/cupertino_store/step_05/lib/model/app_state_model.dart
+++ b/cupertino_store/step_05/lib/model/app_state_model.dart
@@ -74,15 +74,12 @@ class AppStateModel extends foundation.ChangeNotifier {
   }
 
   // Returns a copy of the list of available products, filtered by category.
-  List<Product> getProducts() {
-    if (_selectedCategory == Category.all) {
-      return List.from(_availableProducts);
-    } else {
-      return _availableProducts.where((p) {
-        return p.category == _selectedCategory;
-      }).toList();
-    }
-  }
+  List<Product> getProducts() => switch (_selectedCategory) {
+        Category.all => List.from(_availableProducts),
+        _ => _availableProducts
+            .where((p) => p.category == _selectedCategory)
+            .toList(),
+      };
 
   // Search the product catalog
   List<Product> search(String searchTerms) {

--- a/cupertino_store/step_05/lib/model/products_repository.dart
+++ b/cupertino_store/step_05/lib/model/products_repository.dart
@@ -284,11 +284,8 @@ class ProductsRepository {
     ),
   ];
 
-  static List<Product> loadProducts(Category category) {
-    if (category == Category.all) {
-      return _allProducts;
-    } else {
-      return _allProducts.where((p) => p.category == category).toList();
-    }
-  }
+  static List<Product> loadProducts(Category category) => switch (category) {
+        Category.all => _allProducts,
+        _ => _allProducts.where((p) => p.category == category).toList(),
+      };
 }

--- a/cupertino_store/step_05/pubspec.yaml
+++ b/cupertino_store/step_05/pubspec.yaml
@@ -34,7 +34,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.0.2 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/cupertino_store/step_06/lib/app.dart
+++ b/cupertino_store/step_06/lib/app.dart
@@ -58,28 +58,24 @@ class CupertinoStoreHomePage extends StatelessWidget {
         ],
       ),
       tabBuilder: (context, index) {
-        late final CupertinoTabView returnValue;
-        switch (index) {
-          case 0:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+        return switch (index) {
+          0 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ProductListTab(),
-              );
-            });
-          case 1:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          1 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: SearchTab(),
-              );
-            });
-          case 2:
-            returnValue = CupertinoTabView(builder: (context) {
-              return const CupertinoPageScaffold(
+              ),
+            ),
+          2 => CupertinoTabView(
+              builder: (context) => const CupertinoPageScaffold(
                 child: ShoppingCartTab(),
-              );
-            });
-        }
-        return returnValue;
+              ),
+            ),
+          _ => throw Exception('Invalid index $index'),
+        };
       },
     );
   }

--- a/cupertino_store/step_06/lib/model/app_state_model.dart
+++ b/cupertino_store/step_06/lib/model/app_state_model.dart
@@ -75,13 +75,12 @@ class AppStateModel extends foundation.ChangeNotifier {
 
   // Returns a copy of the list of available products, filtered by category.
   List<Product> getProducts() {
-    if (_selectedCategory == Category.all) {
-      return List.from(_availableProducts);
-    } else {
-      return _availableProducts.where((p) {
-        return p.category == _selectedCategory;
-      }).toList();
-    }
+    return switch (_selectedCategory) {
+      Category.all => List.from(_availableProducts),
+      _ => _availableProducts
+          .where((p) => p.category == _selectedCategory)
+          .toList(),
+    };
   }
 
   // Search the product catalog

--- a/cupertino_store/step_06/lib/model/app_state_model.dart
+++ b/cupertino_store/step_06/lib/model/app_state_model.dart
@@ -74,14 +74,12 @@ class AppStateModel extends foundation.ChangeNotifier {
   }
 
   // Returns a copy of the list of available products, filtered by category.
-  List<Product> getProducts() {
-    return switch (_selectedCategory) {
-      Category.all => List.from(_availableProducts),
-      _ => _availableProducts
-          .where((p) => p.category == _selectedCategory)
-          .toList(),
-    };
-  }
+  List<Product> getProducts() => switch (_selectedCategory) {
+        Category.all => List.from(_availableProducts),
+        _ => _availableProducts
+            .where((p) => p.category == _selectedCategory)
+            .toList(),
+      };
 
   // Search the product catalog
   List<Product> search(String searchTerms) {

--- a/cupertino_store/step_06/lib/model/products_repository.dart
+++ b/cupertino_store/step_06/lib/model/products_repository.dart
@@ -284,11 +284,8 @@ class ProductsRepository {
     ),
   ];
 
-  static List<Product> loadProducts(Category category) {
-    if (category == Category.all) {
-      return _allProducts;
-    } else {
-      return _allProducts.where((p) => p.category == category).toList();
-    }
-  }
+  static List<Product> loadProducts(Category category) => switch (category) {
+        Category.all => _allProducts,
+        _ => _allProducts.where((p) => p.category == category).toList(),
+      };
 }

--- a/cupertino_store/step_06/pubspec.yaml
+++ b/cupertino_store/step_06/pubspec.yaml
@@ -34,7 +34,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.0.2 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Adding Dart 3 patterns and registers to the `cupertino_store` codelab.

The "Building a Cupertino app with Flutter" codelab document has been updated as well.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
