### PR TITLE
Remove `break`s in `namer` codelab

### DIFF
--- a/namer/codelab_rebuild.yaml
+++ b/namer/codelab_rebuild.yaml
@@ -907,7 +907,7 @@ steps:
         patch-u: |
           --- b/namer/step_07_d_use_selectedindex/lib/main.dart
           +++ a/namer/step_07_d_use_selectedindex/lib/main.dart
-          @@ -55,6 +55,18 @@ class _MyHomePageState extends State<MyHomePage> {
+          @@ -55,6 +55,16 @@ class _MyHomePageState extends State<MyHomePage> {
            
              @override
              Widget build(BuildContext context) {
@@ -915,10 +915,8 @@ steps:
           +    switch (selectedIndex) {
           +      case 0:
           +        page = GeneratorPage();
-          +        break;
           +      case 1:
           +        page = Placeholder();
-          +        break;
           +      default:
           +        throw UnimplementedError('no widget for $selectedIndex');
           +    }
@@ -926,7 +924,7 @@ steps:
                return Scaffold(
                  body: Row(
                    children: [
-          @@ -82,7 +94,7 @@ class _MyHomePageState extends State<MyHomePage> {
+          @@ -82,7 +92,7 @@ class _MyHomePageState extends State<MyHomePage> {
                      Expanded(
                        child: Container(
                          color: Theme.of(context).colorScheme.primaryContainer,
@@ -948,10 +946,10 @@ steps:
         patch-u: |
           --- a/namer_app/lib/main.dart
           +++ b/namer_app/lib/main.dart
-          @@ -67,39 +67,41 @@
+          @@ -65,39 +65,41 @@
                    throw UnimplementedError('no widget for $selectedIndex');
                }
-
+ 
           -    return Scaffold(
           -      body: Row(
           -        children: [
@@ -1033,19 +1031,19 @@ steps:
         patch-u: |
           --- b/namer/step_08/lib/main.dart
           +++ a/namer/step_08/lib/main.dart
-          @@ -61,7 +61,7 @@ class _MyHomePageState extends State<MyHomePage> {
-                   page = GeneratorPage();
-                   break;
-                 case 1:
+          @@ -60,7 +60,7 @@ class _MyHomePageState extends State<MyHomePage> {
+                case 0:
+                  page = GeneratorPage();
+                case 1:
           -        page = Placeholder();
           +        page = FavoritesPage();
-                   break;
-                 default:
-                   throw UnimplementedError('no widget for $selectedIndex');
-          @@ -177,3 +177,31 @@ class BigCard extends StatelessWidget {
-               );
-             }
-           }
+                default:
+                  throw UnimplementedError('no widget for $selectedIndex');
+              }
+          @@ -175,3 +175,31 @@ class BigCard extends StatelessWidget {
+              );
+            }
+          }
           +
           +class FavoritesPage extends StatelessWidget {
           +  @override

--- a/namer/codelab_rebuild.yaml
+++ b/namer/codelab_rebuild.yaml
@@ -448,15 +448,7 @@ steps:
         patch-u: |
           --- a/namer_app/lib/main.dart
           +++ b/namer_app/lib/main.dart
-          @@ -68,15 +68,19 @@ class BigCard extends StatelessWidget {
-             @override
-             Widget build(BuildContext context) {
-               final theme = Theme.of(context);
-               final style = theme.textTheme.displayMedium!.copyWith(
-                 color: theme.colorScheme.onPrimary,
-               );
-           
-               return Card(
+          @@ -76,7 +76,11 @@ class BigCard extends StatelessWidget {
                  color: theme.colorScheme.primary,
                  child: Padding(
                    padding: const EdgeInsets.all(20),
@@ -1032,18 +1024,18 @@ steps:
           --- b/namer/step_08/lib/main.dart
           +++ a/namer/step_08/lib/main.dart
           @@ -60,7 +60,7 @@ class _MyHomePageState extends State<MyHomePage> {
-                case 0:
-                  page = GeneratorPage();
-                case 1:
+                 case 0:
+                   page = GeneratorPage();
+                 case 1:
           -        page = Placeholder();
           +        page = FavoritesPage();
-                default:
-                  throw UnimplementedError('no widget for $selectedIndex');
-              }
+                 default:
+                   throw UnimplementedError('no widget for $selectedIndex');
+               }
           @@ -175,3 +175,31 @@ class BigCard extends StatelessWidget {
-              );
-            }
-          }
+               );
+             }
+           }
           +
           +class FavoritesPage extends StatelessWidget {
           +  @override

--- a/namer/codelab_rebuild.yaml
+++ b/namer/codelab_rebuild.yaml
@@ -941,7 +941,7 @@ steps:
           @@ -65,39 +65,41 @@
                    throw UnimplementedError('no widget for $selectedIndex');
                }
- 
+
           -    return Scaffold(
           -      body: Row(
           -        children: [

--- a/namer/step_07_d_use_selectedindex/lib/main.dart
+++ b/namer/step_07_d_use_selectedindex/lib/main.dart
@@ -59,10 +59,8 @@ class _MyHomePageState extends State<MyHomePage> {
     switch (selectedIndex) {
       case 0:
         page = GeneratorPage();
-        break;
       case 1:
         page = Placeholder();
-        break;
       default:
         throw UnimplementedError('no widget for $selectedIndex');
     }

--- a/namer/step_07_e_add_layout_builder/lib/main.dart
+++ b/namer/step_07_e_add_layout_builder/lib/main.dart
@@ -59,10 +59,8 @@ class _MyHomePageState extends State<MyHomePage> {
     switch (selectedIndex) {
       case 0:
         page = GeneratorPage();
-        break;
       case 1:
         page = Placeholder();
-        break;
       default:
         throw UnimplementedError('no widget for $selectedIndex');
     }

--- a/namer/step_08/lib/main.dart
+++ b/namer/step_08/lib/main.dart
@@ -59,10 +59,8 @@ class _MyHomePageState extends State<MyHomePage> {
     switch (selectedIndex) {
       case 0:
         page = GeneratorPage();
-        break;
       case 1:
         page = FavoritesPage();
-        break;
       default:
         throw UnimplementedError('no widget for $selectedIndex');
     }


### PR DESCRIPTION
Re-doing  #1643 to remove breaks from the namer codelab


## Pre-launch Checklist

- [ ] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
