### PR TITLE
Remove `break`s from `pesto_example`

### DIFF
--- a/pesto_flutter/final/lib/presentation/router.dart
+++ b/pesto_flutter/final/lib/presentation/router.dart
@@ -65,16 +65,12 @@ GoRouter buildRouter() {
               switch (index) {
                 case 0:
                   context.go('/notes');
-                  break;
                 case 1:
                   context.go('/');
-                  break;
                 case 2:
                   context.go('/profile');
-                  break;
                 case 3:
                   context.go('/settings');
-                  break;
               }
             },
             child: child,


### PR DESCRIPTION
I was looking for opportunities to use Dart 3 patterns and records but found nothing.

## Pre-launch Checklist

- [ ] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
