### PR TITLE
Use Dart 3 patterns in  codelab code

### DIFF
--- a/cookbook/lib/examples/nested_nav.dart
+++ b/cookbook/lib/examples/nested_nav.dart
@@ -26,20 +26,14 @@ void main() {
         ),
       ),
       onGenerateRoute: (settings) {
-        late Widget page;
-        if (settings.name == routeHome) {
-          page = const HomeScreen();
-        } else if (settings.name == routeSettings) {
-          page = const SettingsScreen();
-        } else if (settings.name!.startsWith(routePrefixDeviceSetup)) {
-          final subRoute =
-              settings.name!.substring(routePrefixDeviceSetup.length);
-          page = SetupFlow(
-            setupPageRoute: subRoute,
-          );
-        } else {
-          throw Exception('Unknown route: ${settings.name}');
-        }
+        Widget page = switch (settings.name) {
+          routeHome => const HomeScreen(),
+          routeSettings => const SettingsScreen(),
+          String name when name.startsWith(routePrefixDeviceSetup) => SetupFlow(
+              setupPageRoute: name.substring(routePrefixDeviceSetup.length),
+            ),
+          _ => throw Exception('Unknown route: ${settings.name}'),
+        };
 
         return MaterialPageRoute<dynamic>(
           builder: (context) {
@@ -145,27 +139,23 @@ class SetupFlowState extends State<SetupFlow> {
   }
 
   Route _onGenerateRoute(RouteSettings settings) {
-    late Widget page;
-    switch (settings.name) {
-      case routeDeviceSetupStartPage:
-        page = WaitingPage(
+    Widget page = switch (settings.name) {
+      routeDeviceSetupStartPage => WaitingPage(
           message: 'Searching for nearby bulb...',
           onWaitComplete: _onDiscoveryComplete,
-        );
-      case routeDeviceSetupSelectDevicePage:
-        page = SelectDevicePage(
+        ),
+      routeDeviceSetupSelectDevicePage => SelectDevicePage(
           onDeviceSelected: _onDeviceSelected,
-        );
-      case routeDeviceSetupConnectingPage:
-        page = WaitingPage(
+        ),
+      routeDeviceSetupConnectingPage => WaitingPage(
           message: 'Connecting...',
           onWaitComplete: _onConnectionEstablished,
-        );
-      case routeDeviceSetupFinishedPage:
-        page = FinishedPage(
+        ),
+      routeDeviceSetupFinishedPage => FinishedPage(
           onFinishPressed: _exitSetup,
-        );
-    }
+        ),
+      _ => throw Exception('Unknown route: ${settings.name}'),
+    };
 
     return MaterialPageRoute<dynamic>(
       builder: (context) {

--- a/cookbook/lib/main.dart
+++ b/cookbook/lib/main.dart
@@ -38,11 +38,11 @@ class Home extends StatelessWidget {
           return ListTile(
             onTap: () => context.go('/${item.path}'),
             leading: Icon(
-              (item.recommendation == Recommendation.yes)
-                  ? const IconData(0x2705)
-                  : (item.recommendation == Recommendation.maybe
-                      ? const IconData(0x2734)
-                      : const IconData(0x26D4)),
+              switch (item.recommendation) {
+                Recommendation.yes => const IconData(0x2705),
+                Recommendation.no => const IconData(0x2734),
+                _ => const IconData(0x26D4),
+              },
             ),
             title: Text(item.name),
             subtitle: Text(item.type),

--- a/cookbook/lib/main.dart
+++ b/cookbook/lib/main.dart
@@ -40,8 +40,8 @@ class Home extends StatelessWidget {
             leading: Icon(
               switch (item.recommendation) {
                 Recommendation.yes => const IconData(0x2705),
-                Recommendation.no => const IconData(0x2734),
-                _ => const IconData(0x26D4),
+                Recommendation.maybe => const IconData(0x2734),
+                Recommendation.no => const IconData(0x26D4),
               },
             ),
             title: Text(item.name),


### PR DESCRIPTION
A couple of refactors to use switch patterns from Dart 3 in the `cookbook` sample.

I am not sure where is this code used, in case that also requires upgrading.

## Pre-launch Checklist

- [ ] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
