### PR TITLE
Explicit Platform and kIsWeb import in `next-gen-ui`

### DIFF
--- a/next-gen-ui/codelab_rebuild.yaml
+++ b/next-gen-ui/codelab_rebuild.yaml
@@ -1630,9 +1630,9 @@ steps:
           // Use of this source code is governed by a BSD-style license that can be
           // found in the LICENSE file.
           
-          import 'dart:io';
+          import 'dart:io' show Platform;
           
-          import 'package:flutter/foundation.dart';
+          import 'package:flutter/foundation.dart' show kIsWeb;
           import 'package:flutter/material.dart';
           import 'package:window_size/window_size.dart';
           
@@ -2428,9 +2428,9 @@ steps:
         patch-u: |
           --- b/next-gen-ui/step_04_a/lib/main.dart
           +++ a/next-gen-ui/step_04_a/lib/main.dart
-          @@ -6,6 +6,7 @@ import 'dart:io';
+          @@ -6,6 +6,7 @@ import 'dart:io' show Platform;
            
-           import 'package:flutter/foundation.dart';
+           import 'package:flutter/foundation.dart' show kIsWeb;
            import 'package:flutter/material.dart';
           +import 'package:flutter_animate/flutter_animate.dart';
            import 'package:window_size/window_size.dart';
@@ -2822,8 +2822,8 @@ steps:
         patch-u: |
           --- b/next-gen-ui/step_05_a/lib/main.dart
           +++ a/next-gen-ui/step_05_a/lib/main.dart
-          @@ -7,8 +7,10 @@ import 'dart:io';
-           import 'package:flutter/foundation.dart';
+          @@ -7,8 +7,10 @@ import 'dart:io' show Platform;
+           import 'package:flutter/foundation.dart' show kIsWeb;
            import 'package:flutter/material.dart';
            import 'package:flutter_animate/flutter_animate.dart';
           +import 'package:provider/provider.dart';

--- a/next-gen-ui/step_01/lib/main.dart
+++ b/next-gen-ui/step_01/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:window_size/window_size.dart';
 

--- a/next-gen-ui/step_02_a/lib/main.dart
+++ b/next-gen-ui/step_02_a/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:window_size/window_size.dart';
 

--- a/next-gen-ui/step_02_b/lib/main.dart
+++ b/next-gen-ui/step_02_b/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:window_size/window_size.dart';
 

--- a/next-gen-ui/step_02_c/lib/main.dart
+++ b/next-gen-ui/step_02_c/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:window_size/window_size.dart';
 

--- a/next-gen-ui/step_03_a/lib/main.dart
+++ b/next-gen-ui/step_03_a/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:window_size/window_size.dart';
 

--- a/next-gen-ui/step_03_b/lib/main.dart
+++ b/next-gen-ui/step_03_b/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:window_size/window_size.dart';
 

--- a/next-gen-ui/step_03_c/lib/main.dart
+++ b/next-gen-ui/step_03_c/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:window_size/window_size.dart';
 

--- a/next-gen-ui/step_04_a/lib/main.dart
+++ b/next-gen-ui/step_04_a/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:window_size/window_size.dart';

--- a/next-gen-ui/step_04_b/lib/main.dart
+++ b/next-gen-ui/step_04_b/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:window_size/window_size.dart';

--- a/next-gen-ui/step_04_c/lib/main.dart
+++ b/next-gen-ui/step_04_c/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:window_size/window_size.dart';

--- a/next-gen-ui/step_04_d/lib/main.dart
+++ b/next-gen-ui/step_04_d/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:window_size/window_size.dart';

--- a/next-gen-ui/step_04_e/lib/main.dart
+++ b/next-gen-ui/step_04_e/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:window_size/window_size.dart';

--- a/next-gen-ui/step_05_a/lib/main.dart
+++ b/next-gen-ui/step_05_a/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:provider/provider.dart';

--- a/next-gen-ui/step_05_b/lib/main.dart
+++ b/next-gen-ui/step_05_b/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:provider/provider.dart';

--- a/next-gen-ui/step_06/lib/main.dart
+++ b/next-gen-ui/step_06/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:provider/provider.dart';


### PR DESCRIPTION
Following the ideas in https://github.com/flutter/website/issues/7798 I have changed the imports needed for `Platform` and `kIsWeb` to be explicitly named.

While the project also includes imports for `dart:ui` or `dart:math`, I did not convert those to Named imports, as the code would become messy with the frequent use of those packages.

The codelab_rebuild has also been updated.

## Pre-launch Checklist

- [ ] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
