### PR TITLE
Explicit Platform import in `ffigen_codelab`

### DIFF
--- a/ffigen_codelab/codelab_rebuild.yaml
+++ b/ffigen_codelab/codelab_rebuild.yaml
@@ -245,7 +245,7 @@ steps:
           // found in the LICENSE file.
           
           import 'dart:ffi';
-          import 'dart:io';
+          import 'dart:io' show Platform;
           import 'package:ffi/ffi.dart' as ffi;
           
           import 'duktape_bindings_generated.dart';
@@ -436,7 +436,7 @@ steps:
           +++ a/ffigen_codelab/step_07/lib/ffigen_app.dart
           @@ -5,6 +5,7 @@
            import 'dart:ffi';
-           import 'dart:io';
+           import 'dart:io' show Platform;
            import 'package:ffi/ffi.dart' as ffi;
           +import 'package:path/path.dart' as p;
            

--- a/ffigen_codelab/step_05/lib/ffigen_app.dart
+++ b/ffigen_codelab/step_05/lib/ffigen_app.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ffi';
-import 'dart:io';
+import 'dart:io' show Platform;
 import 'package:ffi/ffi.dart' as ffi;
 
 import 'duktape_bindings_generated.dart';

--- a/ffigen_codelab/step_06/lib/ffigen_app.dart
+++ b/ffigen_codelab/step_06/lib/ffigen_app.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ffi';
-import 'dart:io';
+import 'dart:io' show Platform;
 import 'package:ffi/ffi.dart' as ffi;
 
 import 'duktape_bindings_generated.dart';

--- a/ffigen_codelab/step_07/lib/ffigen_app.dart
+++ b/ffigen_codelab/step_07/lib/ffigen_app.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ffi';
-import 'dart:io';
+import 'dart:io' show Platform;
 import 'package:ffi/ffi.dart' as ffi;
 import 'package:path/path.dart' as p;
 


### PR DESCRIPTION
Following the ideas in flutter/website#7798 I have changed the imports needed for Platform to be explicitly named.

The codelab_rebuild has also been updated.

I'll updated the codelab document when approved.

## Pre-launch Checklist

- [ ] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
