### PR TITLE
Fix right overflow in namer codelab

### DIFF
--- a/namer/step_08/lib/main.dart
+++ b/namer/step_08/lib/main.dart
@@ -124,8 +124,10 @@ class GeneratorPage extends StatelessWidget {
         children: [
           BigCard(pair: pair),
           SizedBox(height: 10),
-          Row(
-            mainAxisSize: MainAxisSize.min,
+          Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 10,
+            runSpacing: 10,
             children: [
               ElevatedButton.icon(
                 onPressed: () {
@@ -134,7 +136,6 @@ class GeneratorPage extends StatelessWidget {
                 icon: Icon(icon),
                 label: Text('Like'),
               ),
-              SizedBox(width: 10),
               ElevatedButton(
                 onPressed: () {
                   appState.getNext();


### PR DESCRIPTION
The "Like" and "Next" buttons being wrapped in a Row causes a right overflow when the screen gets tiny enough.

Changed the Row to a Wrap with 10 vertical and horizontal spacing, which also removes the need for the SizeBox.

![dif](https://github.com/flutter/codelabs/assets/103767860/2c4c17b4-4463-46ad-a938-945cd015e7e3)

Now the buttons will stack vertically when they run out of space horizontally.

# Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
