### PR TITLE
[In-app Purchase] Improved purchase status enum parsing in Google handler

### DIFF
--- a/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart
@@ -9,6 +9,17 @@ import 'iap_repository.dart';
 import 'products.dart';
 import 'purchase_handler.dart';
 
+NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment completed
+    0 => NonSubscriptionStatus.completed,
+  // Payment pending
+    2 => NonSubscriptionStatus.pending,
+  // Payment expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 class GooglePlayPurchaseHandler extends PurchaseHandler {
   final ap.AndroidPublisherApi androidPublisher;
   final IapRepository iapRepository;
@@ -63,7 +74,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: nonSubscriptionStatusFrom(response.purchaseState),
+        status: _nonSubscriptionStatusFrom(response.purchaseState),
         userId: userId,
         iapSource: IAPSource.googleplay,
       );

--- a/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart
@@ -63,7 +63,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: NonSubscriptionStatus.values[response.purchaseState ?? 0],
+        status: nonSubscriptionStatusFrom(response.purchaseState),
         userId: userId,
         iapSource: IAPSource.googleplay,
       );

--- a/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart
@@ -252,15 +252,15 @@ NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
 
 SubscriptionStatus _subscriptionStatusFrom(int? state) {
   return switch (state) {
-  // Payment pending
+    // Payment pending
     0 => SubscriptionStatus.pending,
-  // Payment received
+    // Payment received
     1 => SubscriptionStatus.active,
-  // Free trial
+    // Free trial
     2 => SubscriptionStatus.active,
-  // Pending deferred upgrade/downgrade
+    // Pending deferred upgrade/downgrade
     3 => SubscriptionStatus.pending,
-  // Expired or cancelled
+    // Expired or cancelled
     _ => SubscriptionStatus.expired,
   };
 }

--- a/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart
@@ -9,17 +9,6 @@ import 'iap_repository.dart';
 import 'products.dart';
 import 'purchase_handler.dart';
 
-NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-  // Payment completed
-    0 => NonSubscriptionStatus.completed,
-  // Payment pending
-    2 => NonSubscriptionStatus.pending,
-  // Payment expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 class GooglePlayPurchaseHandler extends PurchaseHandler {
   final ap.AndroidPublisherApi androidPublisher;
   final IapRepository iapRepository;
@@ -139,7 +128,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: subscriptionStatusFrom(response.paymentState),
+        status: _subscriptionStatusFrom(response.paymentState),
         userId: userId,
         iapSource: IAPSource.googleplay,
         expiryDate: DateTime.fromMillisecondsSinceEpoch(
@@ -251,6 +240,29 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
       subscriptionName,
     );
   }
+}
+
+NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+    0 => NonSubscriptionStatus.completed,
+    2 => NonSubscriptionStatus.pending,
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
+SubscriptionStatus _subscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment pending
+    0 => SubscriptionStatus.pending,
+  // Payment received
+    1 => SubscriptionStatus.active,
+  // Free trial
+    2 => SubscriptionStatus.active,
+  // Pending deferred upgrade/downgrade
+    3 => SubscriptionStatus.pending,
+  // Expired or cancelled
+    _ => SubscriptionStatus.expired,
+  };
 }
 
 /// If a subscription suffix is present (..#) extract the orderId.

--- a/in_app_purchases/complete/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/complete/dart-backend/lib/iap_repository.dart
@@ -81,6 +81,17 @@ enum NonSubscriptionStatus {
   pending,
 }
 
+NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment completed
+    0 => NonSubscriptionStatus.completed,
+  // Payment pending
+    2 => NonSubscriptionStatus.pending,
+  // Expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/complete/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/complete/dart-backend/lib/iap_repository.dart
@@ -81,17 +81,6 @@ enum NonSubscriptionStatus {
   pending,
 }
 
-NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-  // Payment completed
-    0 => NonSubscriptionStatus.completed,
-  // Payment pending
-    2 => NonSubscriptionStatus.pending,
-  // Expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/complete/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/complete/dart-backend/lib/iap_repository.dart
@@ -76,9 +76,9 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
-  pending,
   completed,
   cancelled,
+  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/complete/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/complete/dart-backend/lib/iap_repository.dart
@@ -76,27 +76,12 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
+  pending,
   completed,
   cancelled,
-  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }
-
-SubscriptionStatus subscriptionStatusFrom(int? state) {
-  return switch (state) {
-    // Payment pending
-    0 => SubscriptionStatus.pending,
-    // Payment received
-    1 => SubscriptionStatus.active,
-    // Free trial
-    2 => SubscriptionStatus.active,
-    // Pending deferred upgrade/downgrade
-    3 => SubscriptionStatus.pending,
-    // Expired or cancelled
-    _ => SubscriptionStatus.expired,
-  };
-}
 
 class NonSubscriptionPurchase extends Purchase {
   final NonSubscriptionStatus status;

--- a/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
@@ -81,17 +81,6 @@ enum NonSubscriptionStatus {
   pending,
 }
 
-NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-    // Payment completed
-    0 => NonSubscriptionStatus.completed,
-    // Payment pending
-    2 => NonSubscriptionStatus.pending,
-    // Expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
@@ -76,9 +76,9 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
-  pending,
   completed,
   cancelled,
+  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
@@ -76,9 +76,9 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
+  pending,
   completed,
   cancelled,
-  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
@@ -81,6 +81,17 @@ enum NonSubscriptionStatus {
   pending,
 }
 
+NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+    // Payment completed
+    0 => NonSubscriptionStatus.completed,
+    // Payment pending
+    2 => NonSubscriptionStatus.pending,
+    // Expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_00/dart-backend/lib/iap_repository.dart
@@ -83,21 +83,6 @@ enum NonSubscriptionStatus {
 
 enum SubscriptionStatus { pending, active, expired }
 
-SubscriptionStatus subscriptionStatusFrom(int? state) {
-  return switch (state) {
-    // Payment pending
-    0 => SubscriptionStatus.pending,
-    // Payment received
-    1 => SubscriptionStatus.active,
-    // Free trial
-    2 => SubscriptionStatus.active,
-    // Pending deferred upgrade/downgrade
-    3 => SubscriptionStatus.pending,
-    // Expired or cancelled
-    _ => SubscriptionStatus.expired,
-  };
-}
-
 class NonSubscriptionPurchase extends Purchase {
   final NonSubscriptionStatus status;
 

--- a/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
@@ -81,6 +81,17 @@ enum NonSubscriptionStatus {
   pending,
 }
 
+NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment completed
+    0 => NonSubscriptionStatus.completed,
+  // Payment pending
+    2 => NonSubscriptionStatus.pending,
+  // Expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
@@ -81,17 +81,6 @@ enum NonSubscriptionStatus {
   pending,
 }
 
-NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-  // Payment completed
-    0 => NonSubscriptionStatus.completed,
-  // Payment pending
-    2 => NonSubscriptionStatus.pending,
-  // Expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
@@ -76,9 +76,9 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
-  pending,
   completed,
   cancelled,
+  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
@@ -76,9 +76,9 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
+  pending,
   completed,
   cancelled,
-  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_07/dart-backend/lib/iap_repository.dart
@@ -83,21 +83,6 @@ enum NonSubscriptionStatus {
 
 enum SubscriptionStatus { pending, active, expired }
 
-SubscriptionStatus subscriptionStatusFrom(int? state) {
-  return switch (state) {
-    // Payment pending
-    0 => SubscriptionStatus.pending,
-    // Payment received
-    1 => SubscriptionStatus.active,
-    // Free trial
-    2 => SubscriptionStatus.active,
-    // Pending deferred upgrade/downgrade
-    3 => SubscriptionStatus.pending,
-    // Expired or cancelled
-    _ => SubscriptionStatus.expired,
-  };
-}
-
 class NonSubscriptionPurchase extends Purchase {
   final NonSubscriptionStatus status;
 

--- a/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
@@ -81,6 +81,17 @@ enum NonSubscriptionStatus {
   pending,
 }
 
+NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment completed
+    0 => NonSubscriptionStatus.completed,
+  // Payment pending
+    2 => NonSubscriptionStatus.pending,
+  // Expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
@@ -76,6 +76,7 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
+  pending,
   completed,
   cancelled,
 }

--- a/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
@@ -81,17 +81,6 @@ enum NonSubscriptionStatus {
   pending,
 }
 
-NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-  // Payment completed
-    0 => NonSubscriptionStatus.completed,
-  // Payment pending
-    2 => NonSubscriptionStatus.pending,
-  // Expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
@@ -76,9 +76,9 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
-  pending,
   completed,
   cancelled,
+  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
@@ -83,21 +83,6 @@ enum NonSubscriptionStatus {
 
 enum SubscriptionStatus { pending, active, expired }
 
-SubscriptionStatus subscriptionStatusFrom(int? state) {
-  return switch (state) {
-    // Payment pending
-    0 => SubscriptionStatus.pending,
-    // Payment received
-    1 => SubscriptionStatus.active,
-    // Free trial
-    2 => SubscriptionStatus.active,
-    // Pending deferred upgrade/downgrade
-    3 => SubscriptionStatus.pending,
-    // Expired or cancelled
-    _ => SubscriptionStatus.expired,
-  };
-}
-
 class NonSubscriptionPurchase extends Purchase {
   final NonSubscriptionStatus status;
 

--- a/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_08/dart-backend/lib/iap_repository.dart
@@ -78,7 +78,6 @@ abstract class Purchase {
 enum NonSubscriptionStatus {
   completed,
   cancelled,
-  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/step_09/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/step_09/dart-backend/lib/google_play_purchase_handler.dart
@@ -160,15 +160,15 @@ NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
 
 SubscriptionStatus _subscriptionStatusFrom(int? state) {
   return switch (state) {
-  // Payment pending
+    // Payment pending
     0 => SubscriptionStatus.pending,
-  // Payment received
+    // Payment received
     1 => SubscriptionStatus.active,
-  // Free trial
+    // Free trial
     2 => SubscriptionStatus.active,
-  // Pending deferred upgrade/downgrade
+    // Pending deferred upgrade/downgrade
     3 => SubscriptionStatus.pending,
-  // Expired or cancelled
+    // Expired or cancelled
     _ => SubscriptionStatus.expired,
   };
 }

--- a/in_app_purchases/step_09/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/step_09/dart-backend/lib/google_play_purchase_handler.dart
@@ -54,7 +54,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: NonSubscriptionStatus.values[response.purchaseState ?? 0],
+        status: nonSubscriptionStatusFrom(response.purchaseState),
         userId: userId,
         iapSource: IAPSource.googleplay,
       );

--- a/in_app_purchases/step_09/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/step_09/dart-backend/lib/google_play_purchase_handler.dart
@@ -7,17 +7,6 @@ import 'iap_repository.dart';
 import 'products.dart';
 import 'purchase_handler.dart';
 
-NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-  // Payment completed
-    0 => NonSubscriptionStatus.completed,
-  // Payment pending
-    2 => NonSubscriptionStatus.pending,
-  // Payment expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 class GooglePlayPurchaseHandler extends PurchaseHandler {
   final ap.AndroidPublisherApi androidPublisher;
   final IapRepository iapRepository;
@@ -130,7 +119,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: subscriptionStatusFrom(response.paymentState),
+        status: _subscriptionStatusFrom(response.paymentState),
         userId: userId,
         iapSource: IAPSource.googleplay,
         expiryDate: DateTime.fromMillisecondsSinceEpoch(
@@ -159,6 +148,29 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
     }
     return false;
   }
+}
+
+NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+    0 => NonSubscriptionStatus.completed,
+    2 => NonSubscriptionStatus.pending,
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
+SubscriptionStatus _subscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment pending
+    0 => SubscriptionStatus.pending,
+  // Payment received
+    1 => SubscriptionStatus.active,
+  // Free trial
+    2 => SubscriptionStatus.active,
+  // Pending deferred upgrade/downgrade
+    3 => SubscriptionStatus.pending,
+  // Expired or cancelled
+    _ => SubscriptionStatus.expired,
+  };
 }
 
 /// If a subscription suffix is present (..#) extract the orderId.

--- a/in_app_purchases/step_09/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/step_09/dart-backend/lib/google_play_purchase_handler.dart
@@ -7,6 +7,17 @@ import 'iap_repository.dart';
 import 'products.dart';
 import 'purchase_handler.dart';
 
+NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment completed
+    0 => NonSubscriptionStatus.completed,
+  // Payment pending
+    2 => NonSubscriptionStatus.pending,
+  // Payment expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 class GooglePlayPurchaseHandler extends PurchaseHandler {
   final ap.AndroidPublisherApi androidPublisher;
   final IapRepository iapRepository;
@@ -54,7 +65,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: nonSubscriptionStatusFrom(response.purchaseState),
+        status: _nonSubscriptionStatusFrom(response.purchaseState),
         userId: userId,
         iapSource: IAPSource.googleplay,
       );

--- a/in_app_purchases/step_09/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_09/dart-backend/lib/iap_repository.dart
@@ -81,6 +81,17 @@ enum NonSubscriptionStatus {
   pending,
 }
 
+NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment completed
+    0 => NonSubscriptionStatus.completed,
+  // Payment pending
+    2 => NonSubscriptionStatus.pending,
+  // Expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_09/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_09/dart-backend/lib/iap_repository.dart
@@ -81,17 +81,6 @@ enum NonSubscriptionStatus {
   pending,
 }
 
-NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-  // Payment completed
-    0 => NonSubscriptionStatus.completed,
-  // Payment pending
-    2 => NonSubscriptionStatus.pending,
-  // Expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_09/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_09/dart-backend/lib/iap_repository.dart
@@ -76,9 +76,9 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
-  pending,
   completed,
   cancelled,
+  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/step_09/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_09/dart-backend/lib/iap_repository.dart
@@ -76,27 +76,12 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
+  pending,
   completed,
   cancelled,
-  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }
-
-SubscriptionStatus subscriptionStatusFrom(int? state) {
-  return switch (state) {
-    // Payment pending
-    0 => SubscriptionStatus.pending,
-    // Payment received
-    1 => SubscriptionStatus.active,
-    // Free trial
-    2 => SubscriptionStatus.active,
-    // Pending deferred upgrade/downgrade
-    3 => SubscriptionStatus.pending,
-    // Expired or cancelled
-    _ => SubscriptionStatus.expired,
-  };
-}
 
 class NonSubscriptionPurchase extends Purchase {
   final NonSubscriptionStatus status;

--- a/in_app_purchases/step_10/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/step_10/dart-backend/lib/google_play_purchase_handler.dart
@@ -9,6 +9,17 @@ import 'iap_repository.dart';
 import 'products.dart';
 import 'purchase_handler.dart';
 
+NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment completed
+    0 => NonSubscriptionStatus.completed,
+  // Payment pending
+    2 => NonSubscriptionStatus.pending,
+  // Payment expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 class GooglePlayPurchaseHandler extends PurchaseHandler {
   final ap.AndroidPublisherApi androidPublisher;
   final IapRepository iapRepository;
@@ -63,7 +74,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: nonSubscriptionStatusFrom(response.purchaseState),
+        status: _nonSubscriptionStatusFrom(response.purchaseState),
         userId: userId,
         iapSource: IAPSource.googleplay,
       );

--- a/in_app_purchases/step_10/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/step_10/dart-backend/lib/google_play_purchase_handler.dart
@@ -63,7 +63,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: NonSubscriptionStatus.values[response.purchaseState ?? 0],
+        status: nonSubscriptionStatusFrom(response.purchaseState),
         userId: userId,
         iapSource: IAPSource.googleplay,
       );

--- a/in_app_purchases/step_10/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/step_10/dart-backend/lib/google_play_purchase_handler.dart
@@ -252,15 +252,15 @@ NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
 
 SubscriptionStatus _subscriptionStatusFrom(int? state) {
   return switch (state) {
-  // Payment pending
+    // Payment pending
     0 => SubscriptionStatus.pending,
-  // Payment received
+    // Payment received
     1 => SubscriptionStatus.active,
-  // Free trial
+    // Free trial
     2 => SubscriptionStatus.active,
-  // Pending deferred upgrade/downgrade
+    // Pending deferred upgrade/downgrade
     3 => SubscriptionStatus.pending,
-  // Expired or cancelled
+    // Expired or cancelled
     _ => SubscriptionStatus.expired,
   };
 }

--- a/in_app_purchases/step_10/dart-backend/lib/google_play_purchase_handler.dart
+++ b/in_app_purchases/step_10/dart-backend/lib/google_play_purchase_handler.dart
@@ -9,17 +9,6 @@ import 'iap_repository.dart';
 import 'products.dart';
 import 'purchase_handler.dart';
 
-NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-  // Payment completed
-    0 => NonSubscriptionStatus.completed,
-  // Payment pending
-    2 => NonSubscriptionStatus.pending,
-  // Payment expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 class GooglePlayPurchaseHandler extends PurchaseHandler {
   final ap.AndroidPublisherApi androidPublisher;
   final IapRepository iapRepository;
@@ -139,7 +128,7 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
         ),
         orderId: orderId,
         productId: productData.productId,
-        status: subscriptionStatusFrom(response.paymentState),
+        status: _subscriptionStatusFrom(response.paymentState),
         userId: userId,
         iapSource: IAPSource.googleplay,
         expiryDate: DateTime.fromMillisecondsSinceEpoch(
@@ -251,6 +240,29 @@ class GooglePlayPurchaseHandler extends PurchaseHandler {
       subscriptionName,
     );
   }
+}
+
+NonSubscriptionStatus _nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+    0 => NonSubscriptionStatus.completed,
+    2 => NonSubscriptionStatus.pending,
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
+SubscriptionStatus _subscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment pending
+    0 => SubscriptionStatus.pending,
+  // Payment received
+    1 => SubscriptionStatus.active,
+  // Free trial
+    2 => SubscriptionStatus.active,
+  // Pending deferred upgrade/downgrade
+    3 => SubscriptionStatus.pending,
+  // Expired or cancelled
+    _ => SubscriptionStatus.expired,
+  };
 }
 
 /// If a subscription suffix is present (..#) extract the orderId.

--- a/in_app_purchases/step_10/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_10/dart-backend/lib/iap_repository.dart
@@ -81,6 +81,17 @@ enum NonSubscriptionStatus {
   pending,
 }
 
+NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
+  return switch (state) {
+  // Payment completed
+    0 => NonSubscriptionStatus.completed,
+  // Payment pending
+    2 => NonSubscriptionStatus.pending,
+  // Expired or cancelled
+    _ => NonSubscriptionStatus.cancelled,
+  };
+}
+
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_10/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_10/dart-backend/lib/iap_repository.dart
@@ -81,17 +81,6 @@ enum NonSubscriptionStatus {
   pending,
 }
 
-NonSubscriptionStatus nonSubscriptionStatusFrom(int? state) {
-  return switch (state) {
-  // Payment completed
-    0 => NonSubscriptionStatus.completed,
-  // Payment pending
-    2 => NonSubscriptionStatus.pending,
-  // Expired or cancelled
-    _ => NonSubscriptionStatus.cancelled,
-  };
-}
-
 enum SubscriptionStatus { pending, active, expired }
 
 SubscriptionStatus subscriptionStatusFrom(int? state) {

--- a/in_app_purchases/step_10/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_10/dart-backend/lib/iap_repository.dart
@@ -76,9 +76,9 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
-  pending,
   completed,
   cancelled,
+  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }

--- a/in_app_purchases/step_10/dart-backend/lib/iap_repository.dart
+++ b/in_app_purchases/step_10/dart-backend/lib/iap_repository.dart
@@ -76,27 +76,12 @@ abstract class Purchase {
 }
 
 enum NonSubscriptionStatus {
+  pending,
   completed,
   cancelled,
-  pending,
 }
 
 enum SubscriptionStatus { pending, active, expired }
-
-SubscriptionStatus subscriptionStatusFrom(int? state) {
-  return switch (state) {
-    // Payment pending
-    0 => SubscriptionStatus.pending,
-    // Payment received
-    1 => SubscriptionStatus.active,
-    // Free trial
-    2 => SubscriptionStatus.active,
-    // Pending deferred upgrade/downgrade
-    3 => SubscriptionStatus.pending,
-    // Expired or cancelled
-    _ => SubscriptionStatus.expired,
-  };
-}
 
 class NonSubscriptionPurchase extends Purchase {
   final NonSubscriptionStatus status;


### PR DESCRIPTION
For the [purchaseState](https://github.com/google/googleapis.dart/blob/14cc0510936ff24d96d2aef46938ebfd364896a2/generated/googleapis/lib/androidpublisher/v3.dart#L8893) the possible values are: `0. Purchased 1. Canceled 2. Pending`, but in the in-app purchase example at this [line](https://github.com/flutter/codelabs/blob/ea5a8e00895c1faed76d30528169c5c76cd9c3f4/in_app_purchases/complete/dart-backend/lib/google_play_purchase_handler.dart#L66) we convert the purchaseState into NonSubscriptionStatus in a wrong way.


```
Before
enum NonSubscriptionStatus {
  pending, // 0
  completed, // 1
  cancelled, // 2
}

After
enum NonSubscriptionStatus {
  completed, // 0
  cancelled, // 1
  pending, // 2
}
```

