### PR TITLE
Split PR #2131 into separate PRs: Part 1 ( tfagents-flutter )

### DIFF
--- a/tfagents-flutter/finished/frontend/lib/main.dart
+++ b/tfagents-flutter/finished/frontend/lib/main.dart
@@ -51,7 +51,7 @@ class _PlaneStrikeState extends State<PlaneStrike>
     return MaterialApp(
       title: 'TFAgents Flutter Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: _buildGameBody(),

--- a/tfagents-flutter/step0/frontend/lib/main.dart
+++ b/tfagents-flutter/step0/frontend/lib/main.dart
@@ -51,7 +51,7 @@ class _PlaneStrikeState extends State<PlaneStrike>
     return MaterialApp(
       title: 'TFAgents Flutter Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: _buildGameBody(),

--- a/tfagents-flutter/step1/frontend/lib/main.dart
+++ b/tfagents-flutter/step1/frontend/lib/main.dart
@@ -51,7 +51,7 @@ class _PlaneStrikeState extends State<PlaneStrike>
     return MaterialApp(
       title: 'TFAgents Flutter Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: _buildGameBody(),

--- a/tfagents-flutter/step2/frontend/lib/main.dart
+++ b/tfagents-flutter/step2/frontend/lib/main.dart
@@ -51,7 +51,7 @@ class _PlaneStrikeState extends State<PlaneStrike>
     return MaterialApp(
       title: 'TFAgents Flutter Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: _buildGameBody(),

--- a/tfagents-flutter/step3/frontend/lib/main.dart
+++ b/tfagents-flutter/step3/frontend/lib/main.dart
@@ -51,7 +51,7 @@ class _PlaneStrikeState extends State<PlaneStrike>
     return MaterialApp(
       title: 'TFAgents Flutter Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: _buildGameBody(),

--- a/tfagents-flutter/step4/frontend/lib/main.dart
+++ b/tfagents-flutter/step4/frontend/lib/main.dart
@@ -51,7 +51,7 @@ class _PlaneStrikeState extends State<PlaneStrike>
     return MaterialApp(
       title: 'TFAgents Flutter Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: _buildGameBody(),

--- a/tfagents-flutter/step5/frontend/lib/main.dart
+++ b/tfagents-flutter/step5/frontend/lib/main.dart
@@ -51,7 +51,7 @@ class _PlaneStrikeState extends State<PlaneStrike>
     return MaterialApp(
       title: 'TFAgents Flutter Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: _buildGameBody(),

--- a/tfagents-flutter/step6/frontend/lib/main.dart
+++ b/tfagents-flutter/step6/frontend/lib/main.dart
@@ -51,7 +51,7 @@ class _PlaneStrikeState extends State<PlaneStrike>
     return MaterialApp(
       title: 'TFAgents Flutter Sample App',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: _buildGameBody(),


### PR DESCRIPTION
### Description

This PR is part of a split from a larger PR (#2131) aimed at updating and replace all instances of `primarySwatch` with `ColorScheme.fromSeed` .

## Changes in this PR
 This PR covers all changes in `tfagents-flutter`.

## Pre-launch Checklist

- [X] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
