### PR TITLE
Split PR #2131 into separate PRs: Part 2 ( tfserving-flutter) 

### DIFF
--- a/tfserving-flutter/codelab2/finished/lib/main.dart
+++ b/tfserving-flutter/codelab2/finished/lib/main.dart
@@ -61,7 +61,7 @@ class _TFServingDemoState extends State<TFServingDemo> {
     return MaterialApp(
       title: 'TF Serving Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: Scaffold(

--- a/tfserving-flutter/codelab2/starter/lib/main.dart
+++ b/tfserving-flutter/codelab2/starter/lib/main.dart
@@ -61,7 +61,7 @@ class _TFServingDemoState extends State<TFServingDemo> {
     return MaterialApp(
       title: 'TF Serving Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: Scaffold(


### PR DESCRIPTION
### Description

This PR is part of a split from a larger PR (#2131) aimed at updating and replace all instances of `primarySwatch` with `ColorScheme.fromSeed` .

## Changes in this PR
 This PR covers all changes in `tfserving-flutter`.

## Pre-launch Checklist

- [X] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
