### PR TITLE
Split PR #2131 into separate PRs: Part 3 ( firebase-auth-flutterfire-ui , firebase-get-to-know-flutter  )

### DIFF
--- a/firebase-auth-flutterfire-ui/complete/lib/app.dart
+++ b/firebase-auth-flutterfire-ui/complete/lib/app.dart
@@ -8,7 +8,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: const AuthGate(),

--- a/firebase-auth-flutterfire-ui/start/lib/app.dart
+++ b/firebase-auth-flutterfire-ui/start/lib/app.dart
@@ -8,7 +8,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: const AuthGate(),

--- a/firebase-get-to-know-flutter/step_02/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_02/lib/main.dart
@@ -22,7 +22,7 @@ class App extends StatelessWidget {
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
               highlightColor: Colors.deepPurple,
             ),
-        primarySwatch: Colors.deepPurple,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textTheme: GoogleFonts.robotoTextTheme(
           Theme.of(context).textTheme,
         ),

--- a/firebase-get-to-know-flutter/step_04/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_04/lib/main.dart
@@ -22,7 +22,7 @@ class App extends StatelessWidget {
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
               highlightColor: Colors.deepPurple,
             ),
-        primarySwatch: Colors.deepPurple,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textTheme: GoogleFonts.robotoTextTheme(
           Theme.of(context).textTheme,
         ),

--- a/firebase-get-to-know-flutter/step_05/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_05/lib/main.dart
@@ -106,7 +106,7 @@ class App extends StatelessWidget {
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
               highlightColor: Colors.deepPurple,
             ),
-        primarySwatch: Colors.deepPurple,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textTheme: GoogleFonts.robotoTextTheme(
           Theme.of(context).textTheme,
         ),

--- a/firebase-get-to-know-flutter/step_06/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_06/lib/main.dart
@@ -106,7 +106,7 @@ class App extends StatelessWidget {
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
               highlightColor: Colors.deepPurple,
             ),
-        primarySwatch: Colors.deepPurple,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textTheme: GoogleFonts.robotoTextTheme(
           Theme.of(context).textTheme,
         ),

--- a/firebase-get-to-know-flutter/step_07/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_07/lib/main.dart
@@ -106,7 +106,7 @@ class App extends StatelessWidget {
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
               highlightColor: Colors.deepPurple,
             ),
-        primarySwatch: Colors.deepPurple,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textTheme: GoogleFonts.robotoTextTheme(
           Theme.of(context).textTheme,
         ),

--- a/firebase-get-to-know-flutter/step_09/lib/main.dart
+++ b/firebase-get-to-know-flutter/step_09/lib/main.dart
@@ -121,7 +121,7 @@ class App extends StatelessWidget {
         buttonTheme: Theme.of(context).buttonTheme.copyWith(
               highlightColor: Colors.deepPurple,
             ),
-        primarySwatch: Colors.deepPurple,
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         textTheme: GoogleFonts.robotoTextTheme(
           Theme.of(context).textTheme,
         ),


### PR DESCRIPTION
### Description

This PR is part of a split from a larger PR (#2131) aimed at updating and replace all instances of `primarySwatch` with `ColorScheme.fromSeed` .

## Changes in this PR
 This PR covers changes in `firebase-auth-flutterfire-ui` and `firebase-get-to-know-flutter`.

## Pre-launch Checklist

- [X] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
