### PR TITLE
`namer` Convert from `context.watch` to `context.read` for `MyAppState`

### DIFF
--- a/namer/step_08/lib/main.dart
+++ b/namer/step_08/lib/main.dart
@@ -179,7 +179,7 @@ class BigCard extends StatelessWidget {
 class FavoritesPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    var appState = context.watch<MyAppState>();
+    var appState = context.read<MyAppState>();
 
     if (appState.favorites.isEmpty) {
       return Center(


### PR DESCRIPTION
Appstate watch changed to read – there is nothing to watch for favourites widget.