### PR TITLE
[Homescreen codelab] Update dependencies

### DIFF
--- a/homescreen_codelab/step_03/android/build.gradle
+++ b/homescreen_codelab/step_03/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()

--- a/homescreen_codelab/step_03/pubspec.yaml
+++ b/homescreen_codelab/step_03/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.0.15
-  home_widget: ^0.3.0
+  home_widget: ^0.6.0
 
 
 dev_dependencies:


### PR DESCRIPTION
- Update `home_widget` to 0.6.0, which [adds support for Flutter 3.20+](https://pub.dev/packages/home_widget/changelog#060)
- Bump Kotlin version of the Android project as the fix suggests (see the message below)

```plain
┌─ Flutter Fix ──────────────────────────────────────────────────────────────────────────────────────┐
│ [!] Your project requires a newer version of the Kotlin Gradle plugin.                             │
│ Find the latest version on https://kotlinlang.org/docs/releases.html#release-details, then update  │
│ /Users/marcinwroblewski/Documents/Projects/flutter-codelabs/homescreen_codelab/step_03/android/bui │
│ ld.gradle:                                                                                         │
│ ext.kotlin_version = '<latest-version>'                                                            │
└────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
