### PR TITLE
[forge2d codelab] Use flame_kenney_xml instead of manual XML parsing

### DIFF
--- a/forge2d_game/codelab_rebuild.yaml
+++ b/forge2d_game/codelab_rebuild.yaml
@@ -59,9 +59,9 @@ steps:
       - name: Patch pubspec.yaml
         path: forge2d_game/pubspec.yaml
         patch: |
-          --- b/forge2d_game/step_03/pubspec.yaml
-          +++ a/forge2d_game/step_03/pubspec.yaml
-          @@ -15,9 +15,9 @@ dependencies:
+          --- b/forge2d_game/step_02/pubspec.yaml
+          +++ a/forge2d_game/step_02/pubspec.yaml
+          @@ -16,9 +16,9 @@ dependencies:
              xml: ^6.5.0
            
            dev_dependencies:
@@ -133,7 +133,7 @@ steps:
         patch: |
           --- b/forge2d_game/step_03/pubspec.yaml
           +++ a/forge2d_game/step_03/pubspec.yaml
-          @@ -21,3 +21,6 @@ dev_dependencies:
+          @@ -22,3 +22,6 @@ dev_dependencies:
            
            flutter:
              uses-material-design: true
@@ -11715,29 +11715,26 @@ steps:
           // Copyright 2024 The Flutter Authors. All rights reserved.
           // Use of this source code is governed by a BSD-style license that can be
           // found in the LICENSE file.
-
+          
           import 'dart:async';
-          import 'dart:ui' as ui;
-
+          
           import 'package:flame/components.dart';
-          import 'package:flame/extensions.dart';
           import 'package:flame_forge2d/flame_forge2d.dart';
           import 'package:flame_kenney_xml/flame_kenney_xml.dart';
-          import 'package:flutter/services.dart';
-
+          
           import 'background.dart';
-
+          
           class MyPhysicsGame extends Forge2DGame {
             MyPhysicsGame()
                 : super(
                     gravity: Vector2(0, 10),
                     camera: CameraComponent.withFixedResolution(width: 800, height: 600),
                   );
-
+          
             late final XmlSpriteSheet aliens;
             late final XmlSpriteSheet elements;
             late final XmlSpriteSheet tiles;
-
+          
             @override
             FutureOr<void> onLoad() async {
               final backgroundImage = await images.load('colored_grass.png');
@@ -11755,13 +11752,13 @@ steps:
                   xmlPath: 'spritesheet_tiles.xml',
                 ),
               ]);
-
+          
               aliens = spriteSheets[0];
               elements = spriteSheets[1];
               tiles = spriteSheets[2];
-
+          
               await world.add(Background(sprite: Sprite(backgroundImage)));
-
+          
               return super.onLoad();
             }
           }
@@ -11838,14 +11835,15 @@ steps:
         patch: |
           --- b/forge2d_game/step_04/lib/components/game.dart
           +++ a/forge2d_game/step_04/lib/components/game.dart
-          @@ -13,5 +13,6 @@ import 'package:flame_kenney_xml/flame_kenney_xml.dart';
+          @@ -9,6 +9,7 @@ import 'package:flame_forge2d/flame_forge2d.dart';
+           import 'package:flame_kenney_xml/flame_kenney_xml.dart';
            
            import 'background.dart';
           +import 'ground.dart';
            
            class MyPhysicsGame extends Forge2DGame {
              MyPhysicsGame()
-          @@ -41,9 +42,22 @@ class MyPhysicsGame extends Forge2DGame {
+          @@ -44,7 +45,20 @@ class MyPhysicsGame extends Forge2DGame {
                tiles = spriteSheets[2];
            
                await world.add(Background(sprite: Sprite(backgroundImage)));
@@ -12301,22 +12299,22 @@ steps:
         patch: |
           --- b/forge2d_game/step_05/lib/components/game.dart
           +++ a/forge2d_game/step_05/lib/components/game.dart
-          @@ -3,6 +3,7 @@
+          @@ -3,12 +3,14 @@
            // found in the LICENSE file.
            
            import 'dart:async';
           +import 'dart:math';
-           import 'dart:ui' as ui;
            
            import 'package:flame/components.dart';
-          @@ -13,5 +14,6 @@ import 'package:flame_kenney_xml/flame_kenney_xml.dart';
+           import 'package:flame_forge2d/flame_forge2d.dart';
+           import 'package:flame_kenney_xml/flame_kenney_xml.dart';
            
            import 'background.dart';
           +import 'brick.dart';
            import 'ground.dart';
            
            class MyPhysicsGame extends Forge2DGame {
-          @@ -43,6 +45,7 @@ class MyPhysicsGame extends Forge2DGame {
+          @@ -46,6 +48,7 @@ class MyPhysicsGame extends Forge2DGame {
            
                await world.add(Background(sprite: Sprite(backgroundImage)));
                await addGround();
@@ -12324,7 +12322,7 @@ steps:
            
                return super.onLoad();
              }
-          @@ -58,6 +61,33 @@ class MyPhysicsGame extends Forge2DGame {
+          @@ -61,4 +64,31 @@ class MyPhysicsGame extends Forge2DGame {
                    ),
                ]);
              }
@@ -12521,7 +12519,7 @@ steps:
         patch: |
           --- b/forge2d_game/step_06/lib/components/game.dart
           +++ a/forge2d_game/step_06/lib/components/game.dart
-          @@ -16,6 +16,7 @@ import 'package:xml/xpath.dart';
+          @@ -12,6 +12,7 @@ import 'package:flame_kenney_xml/flame_kenney_xml.dart';
            import 'background.dart';
            import 'brick.dart';
            import 'ground.dart';
@@ -12529,7 +12527,7 @@ steps:
            
            class MyPhysicsGame extends Forge2DGame {
              MyPhysicsGame()
-          @@ -46,6 +47,7 @@ class MyPhysicsGame extends Forge2DGame {
+          @@ -49,6 +50,7 @@ class MyPhysicsGame extends Forge2DGame {
                await world.add(Background(sprite: Sprite(backgroundImage)));
                await addGround();
                unawaited(addBricks());
@@ -12537,7 +12535,7 @@ steps:
            
                return super.onLoad();
              }
-          @@ -88,6 +90,21 @@ class MyPhysicsGame extends Forge2DGame {
+          @@ -91,4 +93,19 @@ class MyPhysicsGame extends Forge2DGame {
                  await Future<void>.delayed(const Duration(milliseconds: 500));
                }
              }
@@ -12557,8 +12555,6 @@ steps:
           +    }
           +  }
            }
-           
-           class XmlSpriteSheet {
       - name: Build web app
         path: forge2d_game
         flutter: build web
@@ -12614,7 +12610,7 @@ steps:
            const brickScale = 0.5;
            
            enum BrickType {
-          @@ -248,7 +250,7 @@ Map<BrickDamage, String> brickFileNames(BrickType type, BrickSize size) {
+          @@ -249,7 +251,7 @@ Map<BrickDamage, String> brickFileNames(BrickType type, BrickSize size) {
              };
            }
            
@@ -12757,14 +12753,13 @@ steps:
       - name: Patch lib/components/game.dart
         path: forge2d_game/lib/components/game.dart
         patch: |
-          --- forge2d_game/step_06/lib/components/game.dart       2024-06-25 01:33:36.366379062 +0200
-          +++ forge2d_game/step_07/lib/components/game.dart       2024-06-25 01:43:51.820430259 +0200
-          @@ -10,10 +10,12 @@
-           import 'package:flame/extensions.dart';
+          --- b/forge2d_game/step_07/lib/components/game.dart
+          +++ a/forge2d_game/step_07/lib/components/game.dart
+          @@ -8,9 +8,11 @@ import 'dart:math';
+           import 'package:flame/components.dart';
            import 'package:flame_forge2d/flame_forge2d.dart';
            import 'package:flame_kenney_xml/flame_kenney_xml.dart';
           +import 'package:flutter/material.dart';
-           import 'package:flutter/services.dart';
            
            import 'background.dart';
            import 'brick.dart';
@@ -12772,7 +12767,7 @@ steps:
            import 'ground.dart';
            import 'player.dart';
            
-          @@ -52,7 +54,7 @@
+          @@ -49,7 +51,7 @@ class MyPhysicsGame extends Forge2DGame {
            
                await world.add(Background(sprite: Sprite(backgroundImage)));
                await addGround();
@@ -12781,7 +12776,7 @@ steps:
                await addPlayer();
            
                return super.onLoad();
-          @@ -107,8 +109,49 @@
+          @@ -104,8 +106,49 @@ class MyPhysicsGame extends Forge2DGame {
              @override
              void update(double dt) {
                super.update(dt);

--- a/forge2d_game/codelab_rebuild.yaml
+++ b/forge2d_game/codelab_rebuild.yaml
@@ -55,7 +55,7 @@ steps:
           }
       - name: Add dependencies
         path: forge2d_game
-        flutter: pub add characters flame flame_forge2d xml
+        flutter: pub add characters flame flame_forge2d flame_kenney_xml xml
       - name: Patch pubspec.yaml
         path: forge2d_game/pubspec.yaml
         patch: |
@@ -11722,9 +11722,8 @@ steps:
           import 'package:flame/components.dart';
           import 'package:flame/extensions.dart';
           import 'package:flame_forge2d/flame_forge2d.dart';
+          import 'package:flame_kenney_xml/flame_kenney_xml.dart';
           import 'package:flutter/services.dart';
-          import 'package:xml/xml.dart';
-          import 'package:xml/xpath.dart';
 
           import 'background.dart';
 
@@ -11741,51 +11740,29 @@ steps:
 
             @override
             FutureOr<void> onLoad() async {
-              final [backgroundImage, aliensImage, elementsImage, tilesImage] = await [
-                images.load('colored_grass.png'),
-                images.load('spritesheet_aliens.png'),
-                images.load('spritesheet_elements.png'),
-                images.load('spritesheet_tiles.png'),
-              ].wait;
-              aliens = XmlSpriteSheet(aliensImage,
-                  await rootBundle.loadString('assets/spritesheet_aliens.xml'));
-              elements = XmlSpriteSheet(elementsImage,
-                  await rootBundle.loadString('assets/spritesheet_elements.xml'));
-              tiles = XmlSpriteSheet(tilesImage,
-                  await rootBundle.loadString('assets/spritesheet_tiles.xml'));
+              final backgroundImage = await images.load('colored_grass.png');
+              final spriteSheets = await Future.wait([
+                XmlSpriteSheet.load(
+                  imagePath: 'spritesheet_aliens.png',
+                  xmlPath: 'spritesheet_aliens.xml',
+                ),
+                XmlSpriteSheet.load(
+                  imagePath: 'spritesheet_elements.png',
+                  xmlPath: 'spritesheet_elements.xml',
+                ),
+                XmlSpriteSheet.load(
+                  imagePath: 'spritesheet_tiles.png',
+                  xmlPath: 'spritesheet_tiles.xml',
+                ),
+              ]);
+
+              aliens = spriteSheets[0];
+              elements = spriteSheets[1];
+              tiles = spriteSheets[2];
 
               await world.add(Background(sprite: Sprite(backgroundImage)));
 
               return super.onLoad();
-            }
-          }
-
-          class XmlSpriteSheet {
-            XmlSpriteSheet(this.image, String xml) {
-              final document = XmlDocument.parse(xml);
-              for (final node in document.xpath('//TextureAtlas/SubTexture')) {
-                final name = node.getAttribute('name')!;
-                final x = double.parse(node.getAttribute('x')!);
-                final y = double.parse(node.getAttribute('y')!);
-                final width = double.parse(node.getAttribute('width')!);
-                final height = double.parse(node.getAttribute('height')!);
-                _rects[name] = Rect.fromLTWH(x, y, width, height);
-              }
-            }
-
-            final ui.Image image;
-            final _rects = <String, Rect>{};
-
-            Sprite getSprite(String name) {
-              final rect = _rects[name];
-              if (rect == null) {
-                throw ArgumentError('Sprite $name not found');
-              }
-              return Sprite(
-                image,
-                srcPosition: rect.topLeft.toVector2(),
-                srcSize: rect.size.toVector2(),
-              );
             }
           }
       - name: Patch lib/main.dart
@@ -11861,8 +11838,7 @@ steps:
         patch: |
           --- b/forge2d_game/step_04/lib/components/game.dart
           +++ a/forge2d_game/step_04/lib/components/game.dart
-          @@ -13,6 +13,7 @@ import 'package:xml/xml.dart';
-           import 'package:xml/xpath.dart';
+          @@ -13,5 +13,6 @@ import 'package:flame_kenney_xml/flame_kenney_xml.dart';
            
            import 'background.dart';
           +import 'ground.dart';
@@ -11870,7 +11846,7 @@ steps:
            class MyPhysicsGame extends Forge2DGame {
              MyPhysicsGame()
           @@ -41,9 +42,22 @@ class MyPhysicsGame extends Forge2DGame {
-                   await rootBundle.loadString('assets/spritesheet_tiles.xml'));
+               tiles = spriteSheets[2];
            
                await world.add(Background(sprite: Sprite(backgroundImage)));
           +    await addGround();
@@ -11890,8 +11866,6 @@ steps:
           +    ]);
           +  }
            }
-           
-           class XmlSpriteSheet {
       - name: Build web app
         path: forge2d_game
         flutter: build web
@@ -12058,6 +12032,7 @@ steps:
             final ui.Size size;
 
             const BrickSize(this.size);
+
             static BrickSize get randomSize => values[Random().nextInt(values.length)];
           }
 
@@ -12334,8 +12309,7 @@ steps:
            import 'dart:ui' as ui;
            
            import 'package:flame/components.dart';
-          @@ -13,6 +14,7 @@ import 'package:xml/xml.dart';
-           import 'package:xml/xpath.dart';
+          @@ -13,5 +14,6 @@ import 'package:flame_kenney_xml/flame_kenney_xml.dart';
            
            import 'background.dart';
           +import 'brick.dart';
@@ -12382,8 +12356,6 @@ steps:
           +    }
           +  }
            }
-           
-           class XmlSpriteSheet {
       - name: Build web app
         path: forge2d_game
         flutter: build web
@@ -12468,7 +12440,7 @@ steps:
             }
 
             @override
-            update(double dt) {
+            void update(double dt) {
               super.update(dt);
 
               if (!body.isAwake) {
@@ -12578,7 +12550,7 @@ steps:
           +      );
           +
           +  @override
-          +  update(dt) {
+          +  void update(double dt) {
           +    super.update(dt);
           +    if (isMounted && world.children.whereType<Player>().isEmpty) {
           +      addPlayer();
@@ -12768,7 +12740,7 @@ steps:
             }
 
             @override
-            update(double dt) {
+            void update(double dt) {
               super.update(dt);
 
               if (position.x > camera.visibleWorldRect.right + 10 ||
@@ -12785,16 +12757,14 @@ steps:
       - name: Patch lib/components/game.dart
         path: forge2d_game/lib/components/game.dart
         patch: |
-          --- b/forge2d_game/step_07/lib/components/game.dart
-          +++ a/forge2d_game/step_07/lib/components/game.dart
-          @@ -9,12 +9,14 @@ import 'dart:ui' as ui;
-           import 'package:flame/components.dart';
+          --- forge2d_game/step_06/lib/components/game.dart       2024-06-25 01:33:36.366379062 +0200
+          +++ forge2d_game/step_07/lib/components/game.dart       2024-06-25 01:43:51.820430259 +0200
+          @@ -10,10 +10,12 @@
            import 'package:flame/extensions.dart';
            import 'package:flame_forge2d/flame_forge2d.dart';
+           import 'package:flame_kenney_xml/flame_kenney_xml.dart';
           +import 'package:flutter/material.dart';
            import 'package:flutter/services.dart';
-           import 'package:xml/xml.dart';
-           import 'package:xml/xpath.dart';
            
            import 'background.dart';
            import 'brick.dart';
@@ -12802,7 +12772,7 @@ steps:
            import 'ground.dart';
            import 'player.dart';
            
-          @@ -46,7 +48,7 @@ class MyPhysicsGame extends Forge2DGame {
+          @@ -52,7 +54,7 @@
            
                await world.add(Background(sprite: Sprite(backgroundImage)));
                await addGround();
@@ -12811,9 +12781,9 @@ steps:
                await addPlayer();
            
                return super.onLoad();
-          @@ -101,9 +103,50 @@ class MyPhysicsGame extends Forge2DGame {
+          @@ -107,8 +109,49 @@
              @override
-             update(dt) {
+             void update(double dt) {
                super.update(dt);
           -    if (isMounted && world.children.whereType<Player>().isEmpty) {
           +    if (isMounted &&

--- a/forge2d_game/step_02/pubspec.yaml
+++ b/forge2d_game/step_02/pubspec.yaml
@@ -4,12 +4,13 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=3.4.0-0 <4.0.0'
+  sdk: '>=3.4.3 <4.0.0'
 
 dependencies:
   characters: ^1.3.0
-  flame: ^1.17.0
-  flame_forge2d: ^0.18.0
+  flame: ^1.18.0
+  flame_forge2d: ^0.18.1
+  flame_kenney_xml: ^0.1.0
   flutter:
     sdk: flutter
   xml: ^6.5.0

--- a/forge2d_game/step_03/lib/components/game.dart
+++ b/forge2d_game/step_03/lib/components/game.dart
@@ -8,9 +8,8 @@ import 'dart:ui' as ui;
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
+import 'package:flame_kenney_xml/flame_kenney_xml.dart';
 import 'package:flutter/services.dart';
-import 'package:xml/xml.dart';
-import 'package:xml/xpath.dart';
 
 import 'background.dart';
 
@@ -27,50 +26,28 @@ class MyPhysicsGame extends Forge2DGame {
 
   @override
   FutureOr<void> onLoad() async {
-    final [backgroundImage, aliensImage, elementsImage, tilesImage] = await [
-      images.load('colored_grass.png'),
-      images.load('spritesheet_aliens.png'),
-      images.load('spritesheet_elements.png'),
-      images.load('spritesheet_tiles.png'),
-    ].wait;
-    aliens = XmlSpriteSheet(aliensImage,
-        await rootBundle.loadString('assets/spritesheet_aliens.xml'));
-    elements = XmlSpriteSheet(elementsImage,
-        await rootBundle.loadString('assets/spritesheet_elements.xml'));
-    tiles = XmlSpriteSheet(tilesImage,
-        await rootBundle.loadString('assets/spritesheet_tiles.xml'));
+    final backgroundImage = await images.load('colored_grass.png');
+    final spriteSheets = await Future.wait([
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_aliens.png',
+        xmlPath: 'spritesheet_aliens.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_elements.png',
+        xmlPath: 'spritesheet_elements.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_tiles.png',
+        xmlPath: 'spritesheet_tiles.xml',
+      ),
+    ]);
+
+    aliens = spriteSheets[0];
+    elements = spriteSheets[1];
+    tiles = spriteSheets[2];
 
     await world.add(Background(sprite: Sprite(backgroundImage)));
 
     return super.onLoad();
-  }
-}
-
-class XmlSpriteSheet {
-  XmlSpriteSheet(this.image, String xml) {
-    final document = XmlDocument.parse(xml);
-    for (final node in document.xpath('//TextureAtlas/SubTexture')) {
-      final name = node.getAttribute('name')!;
-      final x = double.parse(node.getAttribute('x')!);
-      final y = double.parse(node.getAttribute('y')!);
-      final width = double.parse(node.getAttribute('width')!);
-      final height = double.parse(node.getAttribute('height')!);
-      _rects[name] = Rect.fromLTWH(x, y, width, height);
-    }
-  }
-
-  final ui.Image image;
-  final _rects = <String, Rect>{};
-
-  Sprite getSprite(String name) {
-    final rect = _rects[name];
-    if (rect == null) {
-      throw ArgumentError('Sprite $name not found');
-    }
-    return Sprite(
-      image,
-      srcPosition: rect.topLeft.toVector2(),
-      srcSize: rect.size.toVector2(),
-    );
   }
 }

--- a/forge2d_game/step_03/lib/components/game.dart
+++ b/forge2d_game/step_03/lib/components/game.dart
@@ -3,13 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:flame/components.dart';
-import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
 import 'package:flame_kenney_xml/flame_kenney_xml.dart';
-import 'package:flutter/services.dart';
 
 import 'background.dart';
 

--- a/forge2d_game/step_03/pubspec.yaml
+++ b/forge2d_game/step_03/pubspec.yaml
@@ -4,12 +4,13 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=3.4.0-0 <4.0.0'
+  sdk: '>=3.4.3 <4.0.0'
 
 dependencies:
   characters: ^1.3.0
-  flame: ^1.17.0
-  flame_forge2d: ^0.18.0
+  flame: ^1.18.0
+  flame_forge2d: ^0.18.1
+  flame_kenney_xml: ^0.1.0
   flutter:
     sdk: flutter
   xml: ^6.5.0

--- a/forge2d_game/step_04/lib/components/game.dart
+++ b/forge2d_game/step_04/lib/components/game.dart
@@ -3,13 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:flame/components.dart';
-import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
 import 'package:flame_kenney_xml/flame_kenney_xml.dart';
-import 'package:flutter/services.dart';
 
 import 'background.dart';
 import 'ground.dart';

--- a/forge2d_game/step_04/lib/components/game.dart
+++ b/forge2d_game/step_04/lib/components/game.dart
@@ -8,9 +8,8 @@ import 'dart:ui' as ui;
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
+import 'package:flame_kenney_xml/flame_kenney_xml.dart';
 import 'package:flutter/services.dart';
-import 'package:xml/xml.dart';
-import 'package:xml/xpath.dart';
 
 import 'background.dart';
 import 'ground.dart';
@@ -28,18 +27,25 @@ class MyPhysicsGame extends Forge2DGame {
 
   @override
   FutureOr<void> onLoad() async {
-    final [backgroundImage, aliensImage, elementsImage, tilesImage] = await [
-      images.load('colored_grass.png'),
-      images.load('spritesheet_aliens.png'),
-      images.load('spritesheet_elements.png'),
-      images.load('spritesheet_tiles.png'),
-    ].wait;
-    aliens = XmlSpriteSheet(aliensImage,
-        await rootBundle.loadString('assets/spritesheet_aliens.xml'));
-    elements = XmlSpriteSheet(elementsImage,
-        await rootBundle.loadString('assets/spritesheet_elements.xml'));
-    tiles = XmlSpriteSheet(tilesImage,
-        await rootBundle.loadString('assets/spritesheet_tiles.xml'));
+    final backgroundImage = await images.load('colored_grass.png');
+    final spriteSheets = await Future.wait([
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_aliens.png',
+        xmlPath: 'spritesheet_aliens.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_elements.png',
+        xmlPath: 'spritesheet_elements.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_tiles.png',
+        xmlPath: 'spritesheet_tiles.xml',
+      ),
+    ]);
+
+    aliens = spriteSheets[0];
+    elements = spriteSheets[1];
+    tiles = spriteSheets[2];
 
     await world.add(Background(sprite: Sprite(backgroundImage)));
     await addGround();
@@ -57,34 +63,5 @@ class MyPhysicsGame extends Forge2DGame {
           tiles.getSprite('grass.png'),
         ),
     ]);
-  }
-}
-
-class XmlSpriteSheet {
-  XmlSpriteSheet(this.image, String xml) {
-    final document = XmlDocument.parse(xml);
-    for (final node in document.xpath('//TextureAtlas/SubTexture')) {
-      final name = node.getAttribute('name')!;
-      final x = double.parse(node.getAttribute('x')!);
-      final y = double.parse(node.getAttribute('y')!);
-      final width = double.parse(node.getAttribute('width')!);
-      final height = double.parse(node.getAttribute('height')!);
-      _rects[name] = Rect.fromLTWH(x, y, width, height);
-    }
-  }
-
-  final ui.Image image;
-  final _rects = <String, Rect>{};
-
-  Sprite getSprite(String name) {
-    final rect = _rects[name];
-    if (rect == null) {
-      throw ArgumentError('Sprite $name not found');
-    }
-    return Sprite(
-      image,
-      srcPosition: rect.topLeft.toVector2(),
-      srcSize: rect.size.toVector2(),
-    );
   }
 }

--- a/forge2d_game/step_04/pubspec.yaml
+++ b/forge2d_game/step_04/pubspec.yaml
@@ -4,12 +4,13 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=3.4.0-0 <4.0.0'
+  sdk: '>=3.4.3 <4.0.0'
 
 dependencies:
   characters: ^1.3.0
-  flame: ^1.17.0
-  flame_forge2d: ^0.18.0
+  flame: ^1.18.0
+  flame_forge2d: ^0.18.1
+  flame_kenney_xml: ^0.1.0
   flutter:
     sdk: flutter
   xml: ^6.5.0

--- a/forge2d_game/step_05/lib/components/brick.dart
+++ b/forge2d_game/step_05/lib/components/brick.dart
@@ -38,6 +38,7 @@ enum BrickSize {
   final ui.Size size;
 
   const BrickSize(this.size);
+
   static BrickSize get randomSize => values[Random().nextInt(values.length)];
 }
 

--- a/forge2d_game/step_05/lib/components/game.dart
+++ b/forge2d_game/step_05/lib/components/game.dart
@@ -4,13 +4,10 @@
 
 import 'dart:async';
 import 'dart:math';
-import 'dart:ui' as ui;
 
 import 'package:flame/components.dart';
-import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
 import 'package:flame_kenney_xml/flame_kenney_xml.dart';
-import 'package:flutter/services.dart';
 
 import 'background.dart';
 import 'brick.dart';

--- a/forge2d_game/step_05/lib/components/game.dart
+++ b/forge2d_game/step_05/lib/components/game.dart
@@ -9,9 +9,8 @@ import 'dart:ui' as ui;
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
+import 'package:flame_kenney_xml/flame_kenney_xml.dart';
 import 'package:flutter/services.dart';
-import 'package:xml/xml.dart';
-import 'package:xml/xpath.dart';
 
 import 'background.dart';
 import 'brick.dart';
@@ -30,18 +29,25 @@ class MyPhysicsGame extends Forge2DGame {
 
   @override
   FutureOr<void> onLoad() async {
-    final [backgroundImage, aliensImage, elementsImage, tilesImage] = await [
-      images.load('colored_grass.png'),
-      images.load('spritesheet_aliens.png'),
-      images.load('spritesheet_elements.png'),
-      images.load('spritesheet_tiles.png'),
-    ].wait;
-    aliens = XmlSpriteSheet(aliensImage,
-        await rootBundle.loadString('assets/spritesheet_aliens.xml'));
-    elements = XmlSpriteSheet(elementsImage,
-        await rootBundle.loadString('assets/spritesheet_elements.xml'));
-    tiles = XmlSpriteSheet(tilesImage,
-        await rootBundle.loadString('assets/spritesheet_tiles.xml'));
+    final backgroundImage = await images.load('colored_grass.png');
+    final spriteSheets = await Future.wait([
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_aliens.png',
+        xmlPath: 'spritesheet_aliens.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_elements.png',
+        xmlPath: 'spritesheet_elements.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_tiles.png',
+        xmlPath: 'spritesheet_tiles.xml',
+      ),
+    ]);
+
+    aliens = spriteSheets[0];
+    elements = spriteSheets[1];
+    tiles = spriteSheets[2];
 
     await world.add(Background(sprite: Sprite(backgroundImage)));
     await addGround();
@@ -87,34 +93,5 @@ class MyPhysicsGame extends Forge2DGame {
       );
       await Future<void>.delayed(const Duration(milliseconds: 500));
     }
-  }
-}
-
-class XmlSpriteSheet {
-  XmlSpriteSheet(this.image, String xml) {
-    final document = XmlDocument.parse(xml);
-    for (final node in document.xpath('//TextureAtlas/SubTexture')) {
-      final name = node.getAttribute('name')!;
-      final x = double.parse(node.getAttribute('x')!);
-      final y = double.parse(node.getAttribute('y')!);
-      final width = double.parse(node.getAttribute('width')!);
-      final height = double.parse(node.getAttribute('height')!);
-      _rects[name] = Rect.fromLTWH(x, y, width, height);
-    }
-  }
-
-  final ui.Image image;
-  final _rects = <String, Rect>{};
-
-  Sprite getSprite(String name) {
-    final rect = _rects[name];
-    if (rect == null) {
-      throw ArgumentError('Sprite $name not found');
-    }
-    return Sprite(
-      image,
-      srcPosition: rect.topLeft.toVector2(),
-      srcSize: rect.size.toVector2(),
-    );
   }
 }

--- a/forge2d_game/step_05/pubspec.yaml
+++ b/forge2d_game/step_05/pubspec.yaml
@@ -4,13 +4,14 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=3.4.0-0 <4.0.0'
+  sdk: '>=3.4.3 <4.0.0'
 
 dependencies:
   characters: ^1.3.0
   equatable: ^2.0.5
-  flame: ^1.17.0
-  flame_forge2d: ^0.18.0
+  flame: ^1.18.0
+  flame_forge2d: ^0.18.1
+  flame_kenney_xml: ^0.1.0
   flutter:
     sdk: flutter
   xml: ^6.5.0

--- a/forge2d_game/step_06/lib/components/brick.dart
+++ b/forge2d_game/step_06/lib/components/brick.dart
@@ -38,6 +38,7 @@ enum BrickSize {
   final ui.Size size;
 
   const BrickSize(this.size);
+
   static BrickSize get randomSize => values[Random().nextInt(values.length)];
 }
 

--- a/forge2d_game/step_06/lib/components/game.dart
+++ b/forge2d_game/step_06/lib/components/game.dart
@@ -9,9 +9,8 @@ import 'dart:ui' as ui;
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
+import 'package:flame_kenney_xml/flame_kenney_xml.dart';
 import 'package:flutter/services.dart';
-import 'package:xml/xml.dart';
-import 'package:xml/xpath.dart';
 
 import 'background.dart';
 import 'brick.dart';
@@ -31,18 +30,25 @@ class MyPhysicsGame extends Forge2DGame {
 
   @override
   FutureOr<void> onLoad() async {
-    final [backgroundImage, aliensImage, elementsImage, tilesImage] = await [
-      images.load('colored_grass.png'),
-      images.load('spritesheet_aliens.png'),
-      images.load('spritesheet_elements.png'),
-      images.load('spritesheet_tiles.png'),
-    ].wait;
-    aliens = XmlSpriteSheet(aliensImage,
-        await rootBundle.loadString('assets/spritesheet_aliens.xml'));
-    elements = XmlSpriteSheet(elementsImage,
-        await rootBundle.loadString('assets/spritesheet_elements.xml'));
-    tiles = XmlSpriteSheet(tilesImage,
-        await rootBundle.loadString('assets/spritesheet_tiles.xml'));
+    final backgroundImage = await images.load('colored_grass.png');
+    final spriteSheets = await Future.wait([
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_aliens.png',
+        xmlPath: 'spritesheet_aliens.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_elements.png',
+        xmlPath: 'spritesheet_elements.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_tiles.png',
+        xmlPath: 'spritesheet_tiles.xml',
+      ),
+    ]);
+
+    aliens = spriteSheets[0];
+    elements = spriteSheets[1];
+    tiles = spriteSheets[2];
 
     await world.add(Background(sprite: Sprite(backgroundImage)));
     await addGround();
@@ -99,39 +105,10 @@ class MyPhysicsGame extends Forge2DGame {
       );
 
   @override
-  update(dt) {
+  void update(double dt) {
     super.update(dt);
     if (isMounted && world.children.whereType<Player>().isEmpty) {
       addPlayer();
     }
-  }
-}
-
-class XmlSpriteSheet {
-  XmlSpriteSheet(this.image, String xml) {
-    final document = XmlDocument.parse(xml);
-    for (final node in document.xpath('//TextureAtlas/SubTexture')) {
-      final name = node.getAttribute('name')!;
-      final x = double.parse(node.getAttribute('x')!);
-      final y = double.parse(node.getAttribute('y')!);
-      final width = double.parse(node.getAttribute('width')!);
-      final height = double.parse(node.getAttribute('height')!);
-      _rects[name] = Rect.fromLTWH(x, y, width, height);
-    }
-  }
-
-  final ui.Image image;
-  final _rects = <String, Rect>{};
-
-  Sprite getSprite(String name) {
-    final rect = _rects[name];
-    if (rect == null) {
-      throw ArgumentError('Sprite $name not found');
-    }
-    return Sprite(
-      image,
-      srcPosition: rect.topLeft.toVector2(),
-      srcSize: rect.size.toVector2(),
-    );
   }
 }

--- a/forge2d_game/step_06/lib/components/game.dart
+++ b/forge2d_game/step_06/lib/components/game.dart
@@ -4,13 +4,10 @@
 
 import 'dart:async';
 import 'dart:math';
-import 'dart:ui' as ui;
 
 import 'package:flame/components.dart';
-import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
 import 'package:flame_kenney_xml/flame_kenney_xml.dart';
-import 'package:flutter/services.dart';
 
 import 'background.dart';
 import 'brick.dart';

--- a/forge2d_game/step_06/lib/components/player.dart
+++ b/forge2d_game/step_06/lib/components/player.dart
@@ -65,7 +65,7 @@ class Player extends BodyComponent with DragCallbacks {
   }
 
   @override
-  update(double dt) {
+  void update(double dt) {
     super.update(dt);
 
     if (!body.isAwake) {

--- a/forge2d_game/step_06/pubspec.yaml
+++ b/forge2d_game/step_06/pubspec.yaml
@@ -4,13 +4,14 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=3.4.0-0 <4.0.0'
+  sdk: '>=3.4.3 <4.0.0'
 
 dependencies:
   characters: ^1.3.0
   equatable: ^2.0.5
-  flame: ^1.17.0
-  flame_forge2d: ^0.18.0
+  flame: ^1.18.0
+  flame_forge2d: ^0.18.1
+  flame_kenney_xml: ^0.1.0
   flutter:
     sdk: flutter
   xml: ^6.5.0

--- a/forge2d_game/step_07/lib/components/brick.dart
+++ b/forge2d_game/step_07/lib/components/brick.dart
@@ -40,6 +40,7 @@ enum BrickSize {
   final ui.Size size;
 
   const BrickSize(this.size);
+
   static BrickSize get randomSize => values[Random().nextInt(values.length)];
 }
 

--- a/forge2d_game/step_07/lib/components/enemy.dart
+++ b/forge2d_game/step_07/lib/components/enemy.dart
@@ -71,7 +71,7 @@ class Enemy extends BodyComponentWithUserData with ContactCallbacks {
   }
 
   @override
-  update(double dt) {
+  void update(double dt) {
     super.update(dt);
 
     if (position.x > camera.visibleWorldRect.right + 10 ||

--- a/forge2d_game/step_07/lib/components/game.dart
+++ b/forge2d_game/step_07/lib/components/game.dart
@@ -4,14 +4,11 @@
 
 import 'dart:async';
 import 'dart:math';
-import 'dart:ui' as ui;
 
 import 'package:flame/components.dart';
-import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
 import 'package:flame_kenney_xml/flame_kenney_xml.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'background.dart';
 import 'brick.dart';

--- a/forge2d_game/step_07/lib/components/game.dart
+++ b/forge2d_game/step_07/lib/components/game.dart
@@ -9,10 +9,9 @@ import 'dart:ui' as ui;
 import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame_forge2d/flame_forge2d.dart';
+import 'package:flame_kenney_xml/flame_kenney_xml.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:xml/xml.dart';
-import 'package:xml/xpath.dart';
 
 import 'background.dart';
 import 'brick.dart';
@@ -33,18 +32,25 @@ class MyPhysicsGame extends Forge2DGame {
 
   @override
   FutureOr<void> onLoad() async {
-    final [backgroundImage, aliensImage, elementsImage, tilesImage] = await [
-      images.load('colored_grass.png'),
-      images.load('spritesheet_aliens.png'),
-      images.load('spritesheet_elements.png'),
-      images.load('spritesheet_tiles.png'),
-    ].wait;
-    aliens = XmlSpriteSheet(aliensImage,
-        await rootBundle.loadString('assets/spritesheet_aliens.xml'));
-    elements = XmlSpriteSheet(elementsImage,
-        await rootBundle.loadString('assets/spritesheet_elements.xml'));
-    tiles = XmlSpriteSheet(tilesImage,
-        await rootBundle.loadString('assets/spritesheet_tiles.xml'));
+    final backgroundImage = await images.load('colored_grass.png');
+    final spriteSheets = await Future.wait([
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_aliens.png',
+        xmlPath: 'spritesheet_aliens.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_elements.png',
+        xmlPath: 'spritesheet_elements.xml',
+      ),
+      XmlSpriteSheet.load(
+        imagePath: 'spritesheet_tiles.png',
+        xmlPath: 'spritesheet_tiles.xml',
+      ),
+    ]);
+
+    aliens = spriteSheets[0];
+    elements = spriteSheets[1];
+    tiles = spriteSheets[2];
 
     await world.add(Background(sprite: Sprite(backgroundImage)));
     await addGround();
@@ -101,7 +107,7 @@ class MyPhysicsGame extends Forge2DGame {
       );
 
   @override
-  update(dt) {
+  void update(double dt) {
     super.update(dt);
     if (isMounted &&
         world.children.whereType<Player>().isEmpty &&
@@ -147,34 +153,5 @@ class MyPhysicsGame extends Forge2DGame {
       await Future<void>.delayed(const Duration(seconds: 1));
     }
     enemiesFullyAdded = true;
-  }
-}
-
-class XmlSpriteSheet {
-  XmlSpriteSheet(this.image, String xml) {
-    final document = XmlDocument.parse(xml);
-    for (final node in document.xpath('//TextureAtlas/SubTexture')) {
-      final name = node.getAttribute('name')!;
-      final x = double.parse(node.getAttribute('x')!);
-      final y = double.parse(node.getAttribute('y')!);
-      final width = double.parse(node.getAttribute('width')!);
-      final height = double.parse(node.getAttribute('height')!);
-      _rects[name] = Rect.fromLTWH(x, y, width, height);
-    }
-  }
-
-  final ui.Image image;
-  final _rects = <String, Rect>{};
-
-  Sprite getSprite(String name) {
-    final rect = _rects[name];
-    if (rect == null) {
-      throw ArgumentError('Sprite $name not found');
-    }
-    return Sprite(
-      image,
-      srcPosition: rect.topLeft.toVector2(),
-      srcSize: rect.size.toVector2(),
-    );
   }
 }

--- a/forge2d_game/step_07/lib/components/player.dart
+++ b/forge2d_game/step_07/lib/components/player.dart
@@ -67,7 +67,7 @@ class Player extends BodyComponentWithUserData with DragCallbacks {
   }
 
   @override
-  update(double dt) {
+  void update(double dt) {
     super.update(dt);
 
     if (!body.isAwake) {

--- a/forge2d_game/step_07/pubspec.yaml
+++ b/forge2d_game/step_07/pubspec.yaml
@@ -4,13 +4,14 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: '>=3.4.0-0 <4.0.0'
+  sdk: '>=3.4.3 <4.0.0'
 
 dependencies:
   characters: ^1.3.0
   equatable: ^2.0.5
-  flame: ^1.17.0
-  flame_forge2d: ^0.18.0
+  flame: ^1.18.0
+  flame_forge2d: ^0.18.1
+  flame_kenney_xml: ^0.1.0
   flutter:
     sdk: flutter
   xml: ^6.5.0


### PR DESCRIPTION
This simplifies the forge2d codelab by using the flame_kenney_xml package (official Flame package) for parsing the Kenney sprite sheets. (It pretty much contains the same code as @domesticmouse previously wrote for this codelab)

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
