### PR TITLE
Elide `next-gen-ui` from `beta` channel

### DIFF
--- a/flutter_ci_script_beta.sh
+++ b/flutter_ci_script_beta.sh
@@ -27,7 +27,8 @@ declare -a CODELABS=(
   "homescreen_codelab"
   "in_app_purchases"
   "namer"
-  "next-gen-ui"
+  # TODO(domesticmouse): Color.red/green/blue are deprecated
+  # "next-gen-ui"
   "testing_codelab"
   "tfagents-flutter"
   "tfrs-flutter"


### PR DESCRIPTION
The `beta` channel just updated, so `master` failures are trickling down.

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
