### PR TITLE
Simplify `dev.nix`

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -21,7 +21,7 @@
     workspace = {
       # Runs when a workspace is first created
       onCreate = {
-        updateStable = "flutter channel stable && flutter upgrade && for dir in `find . -name pubspec.yaml -exec dirname {} \; | sort`; do pushd $dir ; flutter pub get; popd; done";
+        updateStable = "flutter channel stable && flutter upgrade";
       };
     };
   };


### PR DESCRIPTION
I was being over ambitious with attempting to automatically `flutter pub get` all the things. Turns out, can't subshell in `dev.nix`

## Pre-launch Checklist

- [ ] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
