### PR TITLE
Elide `intro_flutter_gpu` due to breakage on `main`

### DIFF
--- a/flutter_ci_script_master.sh
+++ b/flutter_ci_script_master.sh
@@ -25,7 +25,8 @@ declare -a CODELABS=(
   "haiku_generator"
   "homescreen_codelab"
   "in_app_purchases"
-  "intro_flutter_gpu"
+  # TODO(domesticmouse): Building assets for package:flutter_scene_importer failed.
+  # "intro_flutter_gpu"
   "namer"
   # TODO(domesticmouse): Color.red/green/blue are deprecated
   # "next-gen-ui"


### PR DESCRIPTION
Dealing with build breakage by turning off `intro_flutter_gpu`

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
