### PR TITLE
Do not update patch versions for `dependabot/github-actions`.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,11 @@ updates:
       interval: "daily"
     labels:
       - "autosubmit"
+    # Updating patch versions for "github-actions" is too chatty.
+    # See https://github.com/flutter/flutter/issues/158350.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   # Pip ecosystem.
   - package-ecosystem: "pip"
     directory: "/tfagents-flutter/"


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/158350.