### PR TITLE
Revert "Bump subosito/flutter-action from 2.19.0 to 2.20.0"

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           distribution: "zulu" # See https://github.com/actions/setup-java#supported-distributions
           java-version: "17"
-      - uses: subosito/flutter-action@395322a6cded4e9ed503aebd4cc1965625f8e59a
+      - uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046
         with:
           channel: ${{ matrix.flutter_version }}
       - run: dart --version


### PR DESCRIPTION
Reverts flutter/codelabs#2323

We pin this version across flutter/* repositories. If you would like to update it, let me know.