### PR TITLE
Re-enable `adaptive_app` on `main` CI

### DIFF
--- a/flutter_ci_script_main.sh
+++ b/flutter_ci_script_main.sh
@@ -6,8 +6,7 @@ DIR="${BASH_SOURCE%/*}"
 source "$DIR/flutter_ci_script_shared.sh"
 
 declare -a CODELABS=(
-  # TODO(DomesticMouse): Enable once https://github.com/flutter/flutter/issues/173904 is fixed
-  # "adaptive_app"
+  "adaptive_app"
   "animated-responsive-layout"
   "animations"
   "audio_soloud"


### PR DESCRIPTION
With https://github.com/flutter/flutter/issues/173904 fixed, this should now work

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
